### PR TITLE
always use a 60 mins satellite delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Might need to install PVLive
 pip install git+https://github.com/SheffieldSolar/PV_Live-API#pvlive_api
 ```
 
+## Testing
+
+You can use `pytest` to run tests
+
 ## Experiments
 
 Notes on these experiments are [here](https://docs.google.com/document/d/1fbkfkBzp16WbnCg7RDuRDvgzInA6XQu3xh4NCjV-WDA/edit?usp=sharing).

--- a/configs/datamodule/configuration/app_configuration.yaml
+++ b/configs/datamodule/configuration/app_configuration.yaml
@@ -55,7 +55,7 @@ input_data:
     satellite_image_size_pixels_width: 24
     satellite_meters_per_pixel: 6000
     keep_dawn_dusk_hours: 4
-    live_delay_minutes: 30
+    live_delay_minutes: 60
     is_live: false
     log_level: DEBUG
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nowcasting_utils
 nowcasting_datamodel==1.4.5
-ocf_datapipes
+ocf_datapipes==1.2.33
 ocf_ml_metrics
 numpy
 pandas


### PR DESCRIPTION
# Pull Request

## Description

For live satellite, always use 60 minus satelite delay. Sometimes there is 30 minutes of satellite delay, but this causes a zig zag output of the 0 hour forecast
Fixes #

## How Has This Been Tested?

CI test

- [ ] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
