### PR TITLE
Update app data input to allow 15-minute satellite fallback

### DIFF
--- a/pvnet/app.py
+++ b/pvnet/app.py
@@ -238,7 +238,7 @@ def app(
     logger.info("Downloading zipped satellite data")
     fs = fsspec.open(os.environ["SATELLITE_ZARR_PATH"]).fs
     fs.get(os.environ["SATELLITE_ZARR_PATH"], "latest.zarr.zip")
-    
+
     # Also download 15-minute satellite if it exists
     sat_latest_15 = os.environ["SATELLITE_ZARR_PATH"].replace(".zarr.zip", "_15.zarr.zip")
     if fs.exists(sat_latest_15):

--- a/pvnet/app.py
+++ b/pvnet/app.py
@@ -238,6 +238,12 @@ def app(
     logger.info("Downloading zipped satellite data")
     fs = fsspec.open(os.environ["SATELLITE_ZARR_PATH"]).fs
     fs.get(os.environ["SATELLITE_ZARR_PATH"], "latest.zarr.zip")
+    
+    # Also download 15-minute satellite if it exists
+    sat_latest_15 = os.environ["SATELLITE_ZARR_PATH"].replace(".zarr.zip", "_15.zarr.zip")
+    if fs.exists(sat_latest_15):
+        logger.info("Downloading 15-minute satellite data")
+        fs.get(sat_latest_15, "latest_15.zarr.zip")
 
     # ---------------------------------------------------------------------------
     # 2. Set up data loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nowcasting_utils
-nowcasting_datamodel==1.4.5
-ocf_datapipes==1.2.34
+nowcasting_datamodel==1.4.14
+ocf_datapipes==1.2.41
 ocf_ml_metrics
 numpy
 pandas


### PR DESCRIPTION
# Pull Request

## Description

Update the app to allow 15-minute satellite data to be used in app when the 5-minute data is not available. See openclimatefix/ocf_datapipes#209 for related update to ocf_datapipes.

We don't store 15-minute data in the database unless the 5 minute data is not available. I tested this locally by downloading the 5-minute data. I modified this downloaded data so that the newest time stamp was 2 hours before present, and saved this as `latest.zarr.zip`. I also took the downloaded 5-minute data, filtered it to 15 minutely and named it `latest_15.zarr.zip`. I then used these to run the `app.py` and it ran successfully.

Changes:
- Update requirements
- Download 15-minute data if available

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
