### PR TITLE
Filter quantile metrics to avoid problems at night

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -287,9 +287,9 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         if self.use_quantile_regression:
             # Add fraction below each quantile for calibration
             for i, quantile in enumerate(self.output_quantiles):
-                below_quant = (y <= y_hat[..., i])
-                # Mask values small values, which are dominated by night 
-                mask = y>=0.01
+                below_quant = y <= y_hat[..., i]
+                # Mask values small values, which are dominated by night
+                mask = y >= 0.01
                 losses[f"fraction_below_{quantile}_quantile"] = (below_quant[mask]).float().mean()
 
             # Take median value for remaining metric calculations

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -287,7 +287,10 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         if self.use_quantile_regression:
             # Add fraction below each quantile for calibration
             for i, quantile in enumerate(self.output_quantiles):
-                losses[f"fraction_below_{quantile}_quantile"] = (y <= y_hat[..., i]).mean()
+                below_quant = (y <= y_hat[..., i])
+                # Mask values small values, which are dominated by night 
+                mask = y>=0.01
+                losses[f"fraction_below_{quantile}_quantile"] = (below_quant[mask]).float().mean()
 
             # Take median value for remaining metric calculations
             y_hat = self._quantiles_to_prediction(y_hat)


### PR DESCRIPTION
# Pull Request

## Description

Filter metrics computing the number of values below the predicted quantiles to avoid issues at night. These metrics don't work well where everything should be zero

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
