### PR TITLE
Issue/min sat delay consistency

### DIFF
--- a/configs/datamodule/configuration/app_configuration.yaml
+++ b/configs/datamodule/configuration/app_configuration.yaml
@@ -13,12 +13,6 @@ input_data:
     time_resolution_minutes: 30
     start_datetime: "1900-01-01T00:00:00"
     end_datetime: "2100-01-01T00:00:00"
-    gsp_image_size_pixels_height: 64
-    gsp_image_size_pixels_width: 64
-    gsp_meters_per_pixel: 2000
-    n_gsp_per_example: 32
-    is_live: false
-    log_level: DEBUG
     metadata_only: false
 
   nwp:
@@ -31,13 +25,12 @@ input_data:
       - dswrf
     nwp_image_size_pixels_height: 24
     nwp_image_size_pixels_width: 24
-    nwp_meters_per_pixel: 2000
-    log_level: DEBUG
 
   satellite:
     satellite_zarr_path: latest.zarr.zip
     history_minutes: 90
     forecast_minutes: 0
+    live_delay_minutes: 60
     time_resolution_minutes: 5
     satellite_channels:
       - IR_016
@@ -53,11 +46,6 @@ input_data:
       - WV_073
     satellite_image_size_pixels_height: 24
     satellite_image_size_pixels_width: 24
-    satellite_meters_per_pixel: 6000
-    keep_dawn_dusk_hours: 4
-    live_delay_minutes: 60
-    is_live: false
-    log_level: DEBUG
 
   hrvsatellite:
     hrvsatellite_zarr_path: ""

--- a/configs/datamodule/configuration/gcp_configuration.yaml
+++ b/configs/datamodule/configuration/gcp_configuration.yaml
@@ -14,7 +14,7 @@ input_data:
     metadata_only: false
 
   nwp:
-    nwp_zarr_path: /mnt/disks/nwp/UKV_intermediate_version_7.zarr
+    nwp_zarr_path: /mnt/disks/nwp_rechunk/UKV_intermediate_version_7.1.zarr
     history_minutes: 120
     forecast_minutes: 480
     time_resolution_minutes: 60
@@ -26,13 +26,14 @@ input_data:
 
   satellite:
     satellite_zarr_path:
-      - /mnt/disks/data_ssd/2017_nonhrv.zarr
-      - /mnt/disks/data_ssd/2018_nonhrv.zarr
-      - /mnt/disks/data_ssd/2019_nonhrv.zarr
-      - /mnt/disks/data_ssd/2020_nonhrv.zarr
-      - /mnt/disks/data_ssd/2021_nonhrv.zarr
+      - /mnt/disks/sat/2017_nonhrv.zarr
+      - /mnt/disks/sat/2018_nonhrv.zarr
+      - /mnt/disks/sat/2019_nonhrv.zarr
+      - /mnt/disks/sat/2020_nonhrv.zarr
+      - /mnt/disks/sat/2021_nonhrv.zarr
     history_minutes: 90
     forecast_minutes: 0
+    live_delay_minutes: 30
     time_resolution_minutes: 5
     satellite_channels:
       - IR_016

--- a/configs/datamodule/configuration/gcp_configuration.yaml
+++ b/configs/datamodule/configuration/gcp_configuration.yaml
@@ -14,7 +14,7 @@ input_data:
     metadata_only: false
 
   nwp:
-    nwp_zarr_path: /mnt/disks/nwp_rechunk/UKV_intermediate_version_7.1.zarr
+    nwp_zarr_path: /mnt/disks/nwp/UKV_intermediate_version_7.zarr
     history_minutes: 120
     forecast_minutes: 480
     time_resolution_minutes: 60

--- a/configs/datamodule/configuration/template_configuration.yaml
+++ b/configs/datamodule/configuration/template_configuration.yaml
@@ -3,25 +3,16 @@ general:
   name: template
 
 input_data:
-  data_source_which_defines_geospatial_locations: gsp
   default_forecast_minutes: 120
   default_history_minutes: 60
 
   gsp:
-    gsp_zarr_path: gs://solar-pv-nowcasting-data/PV/GSP/v5/pv_gsp.zarr
+    gsp_zarr_path: gs://solar-pv-nowcasting-data/PV/GSP/v7/pv_gsp.zarr
     history_minutes: 60
     forecast_minutes: 120
     time_resolution_minutes: 30
     start_datetime: "2020-01-01T00:00:00"
     end_datetime: "2021-09-01T00:00:00"
-    gsp_image_size_pixels_height: 64
-    gsp_image_size_pixels_width: 64
-    gsp_meters_per_pixel: 2000
-    n_gsp_per_example: 32
-    is_live: false
-    live_interpolate_minutes: 60
-    live_load_extra_minutes: 60
-    log_level: ERROR
     metadata_only: false
 
   nwp:
@@ -42,8 +33,6 @@ input_data:
       - si10 # 10-metre wind speed | live = unknown
     nwp_image_size_pixels_height: 24
     nwp_image_size_pixels_width: 24
-    nwp_meters_per_pixel: 2000
-    log_level: DEBUG
 
   pv:
     pv_files_groups:
@@ -65,6 +54,7 @@ input_data:
     satellite_zarr_path: gs://solar-pv-nowcasting-data/satellite/EUMETSAT/SEVIRI_RSS/v4/2020_nonhrv.zarr
     history_minutes: 60
     forecast_minutes: 0
+    live_delay_minutes: 30
     time_resolution_minutes: 5
     satellite_channels:
       - IR_016
@@ -80,11 +70,7 @@ input_data:
       - WV_073
     satellite_image_size_pixels_height: 24
     satellite_image_size_pixels_width: 24
-    satellite_meters_per_pixel: 6000
-    keep_dawn_dusk_hours: 4
-    live_delay_minutes: 30
-    is_live: false
-    log_level: DEBUG
+
 
   hrvsatellite:
     hrvsatellite_zarr_path: gs://solar-pv-nowcasting-data/satellite/EUMETSAT/SEVIRI_RSS/v4/2020_hrv.zarr

--- a/configs/datamodule/configuration/template_configuration.yaml
+++ b/configs/datamodule/configuration/template_configuration.yaml
@@ -71,7 +71,6 @@ input_data:
     satellite_image_size_pixels_height: 24
     satellite_image_size_pixels_width: 24
 
-
   hrvsatellite:
     hrvsatellite_zarr_path: gs://solar-pv-nowcasting-data/satellite/EUMETSAT/SEVIRI_RSS/v4/2020_hrv.zarr
     history_minutes: 60

--- a/pvnet/models/multimodal/deep_supervision.py
+++ b/pvnet/models/multimodal/deep_supervision.py
@@ -57,7 +57,7 @@ class Model(BaseModel):
         forecast_minutes: int = 30,
         history_minutes: int = 60,
         sat_history_minutes: Optional[int] = None,
-        min_sat_delay_minutes: Optional[int] = 15,
+        min_sat_delay_minutes: Optional[int] = 30,
         nwp_forecast_minutes: Optional[int] = None,
         nwp_history_minutes: Optional[int] = None,
         sat_image_size_pixels: int = 64,

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -53,7 +53,7 @@ class Model(BaseModel):
         forecast_minutes: int = 30,
         history_minutes: int = 60,
         sat_history_minutes: Optional[int] = None,
-        min_sat_delay_minutes: Optional[int] = 15,
+        min_sat_delay_minutes: Optional[int] = 30,
         nwp_forecast_minutes: Optional[int] = None,
         nwp_history_minutes: Optional[int] = None,
         sat_image_size_pixels: int = 64,

--- a/pvnet/models/multimodal/weather_residual.py
+++ b/pvnet/models/multimodal/weather_residual.py
@@ -63,7 +63,7 @@ class Model(BaseModel):
         forecast_minutes: int = 30,
         history_minutes: int = 60,
         sat_history_minutes: Optional[int] = None,
-        min_sat_delay_minutes: Optional[int] = 15,
+        min_sat_delay_minutes: Optional[int] = 30,
         nwp_forecast_minutes: Optional[int] = None,
         nwp_history_minutes: Optional[int] = None,
         sat_image_size_pixels: int = 64,


### PR DESCRIPTION
# Pull Request

## Description

Closes #63 

- Update the default values for `min_sat_delay_minutes` to be consistent with what we get in production
- Update data configs to use allow min satellite delay to be passed to into the pvnet datapipe combined with changes in openclimatefix/ocf_datapipes#219
- Tidy some of the data configs

Note that the `min_sat_delay_minutes` model parameter should be set to the same value as `satellite.live_delay_minutes` in the data config.

Also note that I have updated the config `gcp_configuration.yaml` to have `live_delay_minutes=30` but have updated the `app_configuration.yaml` to have `live_delay_minutes=60`. These are different because our production system currently makes satellite data available so that the delay alternates between 30 and 60 minutes. Ideally (reflected in `gcp_configuration.yaml`) the model could use the data from -60 to -30 minutes if it is there and ignore it if it is missing (and hence filled with zeros). In practice (as reflected in `app_configuration.yaml`) we found this may cause our predictions to alternate between higher and lower depending on the delay, so in production we simplify to use a constant 60 minute delay.



## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
