### PR TITLE
add default models to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,17 @@ RUN pip install -r app/requirements.txt
 COPY pvnet/ app/pvnet/
 COPY tests/ app/tests/
 COPY configs/ app/configs/
+COPY scripts/ app/scripts/
 
 # change to app folder
 WORKDIR /app
 
 # install library
 RUN pip install -e .
+
+# download models so app can used cached
+RUN python scripts/cache_default_models.py
+
 
 RUN if [ "$TESTING" = 1 ]; then pip install pytest pytest-cov coverage; fi
 

--- a/pvnet/app.py
+++ b/pvnet/app.py
@@ -33,10 +33,11 @@ from ocf_datapipes.training.pvnet import construct_sliced_data_pipeline
 from ocf_datapipes.transform.numpy.batch.sun_position import ELEVATION_MEAN, ELEVATION_STD
 from ocf_datapipes.utils.consts import BatchKey
 from ocf_datapipes.utils.utils import stack_np_examples_into_batch
-from pvnet_summation.models.base_model import BaseModel as SummationBaseModel
 from sqlalchemy.orm import Session
 from torchdata.dataloader2 import DataLoader2, MultiProcessingReadingService
 from torchdata.datapipes.iter import IterableWrapper
+
+from pvnet_summation.models.base_model import BaseModel as SummationBaseModel
 
 import pvnet
 from pvnet.data.datamodule import batch_to_tensor, copy_batch_to_device
@@ -64,16 +65,13 @@ all_gsp_ids = list(range(1, 318))
 batch_size = 10
 
 # Huggingfacehub model repo and commit for PVNet (GSP-level model)
-model_name = os.getenv("APP_MODEL", default="openclimatefix/pvnet_v2")
-model_version = os.getenv("APP_MODEL_VERSION", default="96ac8c67fa8663844ddcfa82aece51ef94f34453")
+default_model_name = "openclimatefix/pvnet_v2"
+default_model_version = "96ac8c67fa8663844ddcfa82aece51ef94f34453"
 
 # Huggingfacehub model repo and commit for PVNet summation (GSP sum to national model)
 # If summation_model_name is set to None, a simple sum is computed instead
-summation_model_name = os.getenv("APP_SUMMATION_MODEL", default="openclimatefix/pvnet_v2_summation")
-summation_model_version = os.getenv(
-    "APP_SUMMATION_MODEL", default="4a145d74c725ffc72f482025d3418659a6869c94"
-)
-
+default_summation_model_name = "openclimatefix/pvnet_v2_summation"
+default_summation_model_version = "4a145d74c725ffc72f482025d3418659a6869c94"
 
 model_name_ocf_db = "pvnet_v2"
 use_adjuster = os.getenv("USE_ADJUSTER", "True").lower() == "true"
@@ -214,6 +212,12 @@ def app(
 
     logger.info(f"Using `pvnet` library version: {pvnet.__version__}")
     logger.info(f"Using {num_workers} workers")
+    
+    # Allow environment overwrite of model
+    model_name = os.getenv("APP_MODEL", default=default_model_name)
+    model_version = os.getenv("APP_MODEL_VERSION", default=default_model_version)
+    summation_model_name = os.getenv("APP_SUMMATION_MODEL", default=default_summation_model_name)
+    summation_model_version = os.getenv("APP_SUMMATION_MODEL", default=default_summation_model_version)
 
     # ---------------------------------------------------------------------------
     # 0. If inference datetime is None, round down to last 30 minutes

--- a/scripts/cache_default_models.py
+++ b/scripts/cache_default_models.py
@@ -8,6 +8,7 @@ import typer
 from pvnet_summation.models.base_model import BaseModel as SummationBaseModel
 
 from pvnet.app import (
+    default_model_name,
     default_model_version,
     default_summation_model_name,
     default_summation_model_version,
@@ -19,7 +20,7 @@ def main():
     """Download model from Huggingface and save it to cache."""
     # Model will be downloaded and saved to cache on disk
     PVNetBaseModel.from_pretrained(
-        default_summation_model_name,
+        default_model_name,
         revision=default_model_version,
     )
     

--- a/scripts/cache_default_models.py
+++ b/scripts/cache_default_models.py
@@ -19,12 +19,12 @@ def main():
     """Download model from Huggingface and save it to cache.
     """
     # Model will be downloaded and saved to cache on disk
-    model = SummationBaseModel.from_pretrained(
+    model = PVNetBaseModel.from_pretrained(
         default_summation_model_name,
         revision=default_model_version,
     )
     # Model will be downloaded and saved to cache on disk
-    model = PVNetBaseModel.from_pretrained(
+    model = SummationBaseModel.from_pretrained(
         default_summation_model_name,
         revision=default_summation_model_version,
     )

--- a/scripts/cache_default_models.py
+++ b/scripts/cache_default_models.py
@@ -1,0 +1,33 @@
+"""A script to download default models from huggingface.
+
+Downloading these model files in the build means we do not need to download them each time the app
+is run. 
+"""
+
+from pvnet.models.base_model import BaseModel as PVNetBaseModel
+from pvnet_summation.models.base_model import BaseModel as SummationBaseModel
+
+import typer
+from pvnet.app import (
+    default_model_name, 
+    default_model_version,
+    default_summation_model_name,
+    default_summation_model_version,
+)
+
+def main():
+    """Download model from Huggingface and save it to cache.
+    """
+    # Model will be downloaded and saved to cache on disk
+    model = SummationBaseModel.from_pretrained(
+        default_summation_model_name,
+        revision=default_model_version,
+    )
+    # Model will be downloaded and saved to cache on disk
+    model = PVNetBaseModel.from_pretrained(
+        default_summation_model_name,
+        revision=default_summation_model_version,
+    )
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
# Pull Request

## Description

Add default models to the docker image. The models are on the order of 100MB in size for pvnet and the summation model. The models will be saved to the on-disk model cache and this means we do not need to download them from huggingface each time we run the app.

This seems neater and makes us less susceptible to rare huggingface outages, as happened today.


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
