### PR TITLE
Fix multiprocessing for batch creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ conda create -n ocf_datapipes python=3.10
 Then go inside the ocf_datapipes repo to add packages
 
 ```bash
-pip install -r requirements.txt requirements-dev.txt
+pip install -r requirements.txt -r requirements-dev.txt
 ```
 
 Then exit this environment, and enter back into the pvnet conda environment and install ocf_datapies in editable mode (-e). This means the package is directly linked to the source code in the ocf_datapies repo.

--- a/scripts/save_batches.py
+++ b/scripts/save_batches.py
@@ -15,6 +15,13 @@ python save_batches.py \
 ```
 
 """
+# This is needed to get multiprocessing/multiple workers to behave 
+try:
+    import torch.multiprocessing as mp
+    mp.set_start_method('spawn', force=True)
+except RuntimeError:
+    pass
+
 import logging
 import os
 import shutil

--- a/scripts/save_batches.py
+++ b/scripts/save_batches.py
@@ -15,10 +15,11 @@ python save_batches.py \
 ```
 
 """
-# This is needed to get multiprocessing/multiple workers to behave 
+# This is needed to get multiprocessing/multiple workers to behave
 try:
     import torch.multiprocessing as mp
-    mp.set_start_method('spawn', force=True)
+
+    mp.set_start_method("spawn", force=True)
 except RuntimeError:
     pass
 


### PR DESCRIPTION
# Pull Request

## Description

- Adding in a fix to the repo (that @dfulu had found and been using locally) that helps use multiprocessing/multiple workers when creating training batches

- Also changing one pip command in the readme 


## How Has This Been Tested?

This has been tested locally by @dfulu and myself, when specifying num_workers > 1 in the [streamed batches config](https://github.com/openclimatefix/PVNet/blob/main/configs.example/datamodule/streamed_batches.yaml) it stops the script from hanging for long periods.  


## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
