### PR TITLE
Only ensemble if needed

### DIFF
--- a/scripts/checkpoint_to_huggingface.py
+++ b/scripts/checkpoint_to_huggingface.py
@@ -41,7 +41,7 @@ def push_to_huggingface(
 
     os.path.dirname(os.path.abspath(__file__))
 
-    is_ensemble = len(checkpoint_dir_paths)
+    is_ensemble = len(checkpoint_dir_paths) > 1
 
     # Check if checkpoint dir name is wandb run ID
     if wandb_ids == []:


### PR DESCRIPTION
A small bug meant we were converting models to ensemble even if there was only one model. This fixes the mistake so if there is only a single model an ensemble is not made