### PR TITLE
Remove references to old datamodule config parameters

### DIFF
--- a/configs.example/experiment/baseline.yaml
+++ b/configs.example/experiment/baseline.yaml
@@ -19,7 +19,3 @@ validate_only: "1" # by putting this key in the config file, the model does not 
 trainer:
   min_epochs: 1
   max_epochs: 1
-
-datamodule:
-  n_train_data: 2
-  n_val_data: 10

--- a/configs.example/experiment/conv3d_sat_nwp.yaml
+++ b/configs.example/experiment/conv3d_sat_nwp.yaml
@@ -19,9 +19,5 @@ trainer:
   min_epochs: 1
   max_epochs: 10
 
-datamodule:
-  n_train_data: 4000
-  n_val_data: 400
-
 model:
   conv3d_channels: 32

--- a/configs.example/experiment/example_simple.yaml
+++ b/configs.example/experiment/example_simple.yaml
@@ -22,8 +22,6 @@ trainer:
   max_epochs: 2
 
 datamodule:
-  n_train_data: 2
-  n_val_data: 2
-  fake_data: 1
+  batch_size: 32
 
 validate_only: "1" # by putting this key in the config file, the model does not get trained.


### PR DESCRIPTION
# Pull Request

## Description
Removing references in the example config files to old datamodule config parameters (`n_train_data` and `n_val_data`) which are no longer used in the [datamodule class](https://github.com/openclimatefix/PVNet/blob/main/pvnet/data/base.py#L8) (limiting number of batches is done through the trainer config parameters instead i.e `limit_train_batches`) 

This is to make it slightly clearer when looking at the examples what parameters are still in use. 


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
