### PR TITLE
Add PVnet weighted loss

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -363,7 +363,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         losses = {}
 
         if self.use_quantile_regression:
-            losses["quantile_loss"] = self._quantile_loss(y_hat, y)
+            losses["quantile_loss"] = self._calculate_qauntile_loss(y_hat, y)
             y_hat = self._quantiles_to_prediction(y_hat)
 
         # calculate mse, mae

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -67,6 +67,7 @@ class Model(MultimodalBaseModel):
         num_embeddings: Optional[int] = 318,
         timestep_intervals_to_plot: Optional[list[int]] = None,
         adapt_batches: Optional[bool] = False,
+        use_weighted_loss: Optional[bool] = False,
     ):
         """Neural network which combines information from different sources.
 
@@ -123,6 +124,7 @@ class Model(MultimodalBaseModel):
             adapt_batches: If set to true, we attempt to slice the batches to the expected shape for
                 the model to use. This allows us to overprepare batches and slice from them for the
                 data we need for a model run.
+            use_weighted_loss: Whether to use a weighted loss function
         """
 
         self.include_gsp_yield_history = include_gsp_yield_history
@@ -145,6 +147,7 @@ class Model(MultimodalBaseModel):
             target_key=target_key,
             interval_minutes=interval_minutes,
             timestep_intervals_to_plot=timestep_intervals_to_plot,
+            use_weighted_loss=use_weighted_loss
         )
 
         # Number of features expected by the output_network

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,3 +264,9 @@ def multimodal_model(multimodal_model_kwargs):
 def multimodal_quantile_model(multimodal_model_kwargs):
     model = Model(output_quantiles=[0.1, 0.5, 0.9], **multimodal_model_kwargs)
     return model
+
+
+@pytest.fixture()
+def multimodal_weighted_quantile_model(multimodal_model_kwargs):
+    model = Model(output_quantiles=[0.1, 0.5, 0.9], **multimodal_model_kwargs, use_weighted_loss=True)
+    return model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,5 +268,7 @@ def multimodal_quantile_model(multimodal_model_kwargs):
 
 @pytest.fixture()
 def multimodal_weighted_quantile_model(multimodal_model_kwargs):
-    model = Model(output_quantiles=[0.1, 0.5, 0.9], **multimodal_model_kwargs, use_weighted_loss=True)
+    model = Model(
+        output_quantiles=[0.1, 0.5, 0.9], **multimodal_model_kwargs, use_weighted_loss=True
+    )
     return model

--- a/tests/models/multimodal/test_multimodal.py
+++ b/tests/models/multimodal/test_multimodal.py
@@ -34,3 +34,20 @@ def test_quantile_model_backward(multimodal_quantile_model, sample_batch):
 
     # Backwards on sum drives sum to zero
     y_quantiles.sum().backward()
+
+
+def test_weighted_quantile_model_forward(multimodal_weighted_quantile_model, sample_batch):
+    y_quantiles = multimodal_weighted_quantile_model(sample_batch)
+
+    # check output is the correct shape
+    # batch size=2, forecast_len=15, num_quantiles=3
+    assert tuple(y_quantiles.shape) == (2, 16, 3), y_quantiles.shape
+
+
+def test_weighted_quantile_model_backward(multimodal_weighted_quantile_model, sample_batch):
+    opt = SGD(multimodal_weighted_quantile_model.parameters(), lr=0.001)
+
+    y_quantiles = multimodal_weighted_quantile_model(sample_batch)
+
+    # Backwards on sum drives sum to zero
+    y_quantiles.sum().backward()


### PR DESCRIPTION
# Pull Request

## Description

Adds weighted loss for quantile loss to help with longer forecast horizons, and ensuring the model focuses on shorter timescales as well.

Fixes #153 

## How Has This Been Tested?

Unit tests

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
