### PR TITLE
Force using CPU to get e2e test working locally with macs/mps

### DIFF
--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -2,5 +2,5 @@ import lightning
 
 
 def test_model_trainer_fit(multimodal_model, sample_train_val_datamodule):
-    trainer = lightning.pytorch.trainer.trainer.Trainer(fast_dev_run=True, accelerator='cpu')
+    trainer = lightning.pytorch.trainer.trainer.Trainer(fast_dev_run=True, accelerator="cpu")
     trainer.fit(model=multimodal_model, datamodule=sample_train_val_datamodule)

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -2,5 +2,5 @@ import lightning
 
 
 def test_model_trainer_fit(multimodal_model, sample_train_val_datamodule):
-    trainer = lightning.pytorch.trainer.trainer.Trainer(fast_dev_run=True)
+    trainer = lightning.pytorch.trainer.trainer.Trainer(fast_dev_run=True, accelerator='cpu')
     trainer.fit(model=multimodal_model, datamodule=sample_train_val_datamodule)


### PR DESCRIPTION
# Pull Request

## Description

When running the PVNet e2e test locally on a mac it fails with a MPS tensor datatype error, this PR forces the CPU to be used to avoid this issue (means the local test mirrors what runs in Github/through the CI)


## How Has This Been Tested?

By running tests locally and checking the local error was fixed

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
