### PR TITLE
Fix the horizon graph training on GPU

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -521,7 +521,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
 
         # Store these to make horizon accuracy plot
         self._horizon_maes.append(
-            {i: losses[f"MAE_horizon/step_{i:03}"] for i in range(self.forecast_len)}
+            {i: losses[f"MAE_horizon/step_{i:03}"].cpu().numpy() for i in range(self.forecast_len)}
         )
 
         logged_losses = {f"{k}/val": v for k, v in losses.items()}


### PR DESCRIPTION
# Pull Request

Horizon loss graph fails when training on GPU since the loss values are GPU tensors. This fixes the problem by converting to numpy arrays when adding to store
