### PR TITLE
Fix site pvnet datamodule get datapipe

### DIFF
--- a/pvnet/data/pv_site_datamodule.py
+++ b/pvnet/data/pv_site_datamodule.py
@@ -2,7 +2,12 @@
 import glob
 
 from ocf_datapipes.batch import BatchKey, batch_to_tensor, stack_np_examples_into_batch
-from ocf_datapipes.training.pvnet_site import pvnet_site_netcdf_datapipe, pvnet_site_datapipe, uncombine_from_single_dataset, split_dataset_dict_dp, ConvertToNumpyBatchIterDataPipe
+from ocf_datapipes.training.pvnet_site import (
+    pvnet_site_datapipe,
+    pvnet_site_netcdf_datapipe,
+    split_dataset_dict_dp,
+    uncombine_from_single_dataset,
+)
 
 from pvnet.data.base import BaseDataModule
 

--- a/pvnet/data/pv_site_datamodule.py
+++ b/pvnet/data/pv_site_datamodule.py
@@ -2,7 +2,7 @@
 import glob
 
 from ocf_datapipes.batch import BatchKey, batch_to_tensor, stack_np_examples_into_batch
-from ocf_datapipes.training.pvnet_site import pvnet_site_netcdf_datapipe
+from ocf_datapipes.training.pvnet_site import pvnet_site_netcdf_datapipe, pvnet_site_datapipe
 
 from pvnet.data.base import BaseDataModule
 
@@ -11,8 +11,10 @@ class PVSiteDataModule(BaseDataModule):
     """Datamodule for training pvnet site and using pvnet site pipeline in `ocf_datapipes`."""
 
     def _get_datapipe(self, start_time, end_time):
-        data_pipeline = pvnet_site_netcdf_datapipe(
-            keys=["pv", "nwp"],
+        data_pipeline = pvnet_site_datapipe(
+            self.configuration, 
+            start_time=start_time,
+            end_time=end_time
         )
 
         data_pipeline = (

--- a/pvnet/data/pv_site_datamodule.py
+++ b/pvnet/data/pv_site_datamodule.py
@@ -2,7 +2,7 @@
 import glob
 
 from ocf_datapipes.batch import BatchKey, batch_to_tensor, stack_np_examples_into_batch
-from ocf_datapipes.training.pvnet_site import pvnet_site_netcdf_datapipe, pvnet_site_datapipe
+from ocf_datapipes.training.pvnet_site import pvnet_site_netcdf_datapipe, pvnet_site_datapipe, uncombine_from_single_dataset, split_dataset_dict_dp, ConvertToNumpyBatchIterDataPipe
 
 from pvnet.data.base import BaseDataModule
 
@@ -12,10 +12,12 @@ class PVSiteDataModule(BaseDataModule):
 
     def _get_datapipe(self, start_time, end_time):
         data_pipeline = pvnet_site_datapipe(
-            self.configuration, 
+            self.configuration,
             start_time=start_time,
-            end_time=end_time
+            end_time=end_time,
         )
+        data_pipeline = data_pipeline.map(uncombine_from_single_dataset).map(split_dataset_dict_dp)
+        data_pipeline = data_pipeline.pvnet_site_convert_to_numpy_batch()
 
         data_pipeline = (
             data_pipeline.batch(self.batch_size)


### PR DESCRIPTION
# Pull Request

## Description
This PR includes changes to the PV site datamodule to use the correct site pvnet datapipes and mappings in the case of streaming data for training rather than creating intermediate batches (done less frequently but a nice to have just in case)


## How Has This Been Tested?

This has been tested by running training with PVNet on debug mode succesfully using this datamodule but not pointing to premade batches (points to a config file to stream batches instead) to make sure the modified method is called

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
