### PR TITLE
save configuration to wandb

### DIFF
--- a/pvnet/training.py
+++ b/pvnet/training.py
@@ -124,7 +124,9 @@ def train(config: DictConfig) -> Optional[float]:
 
                 # upload configuration up to wandb
                 OmegaConf.save(config, "./experiment_config.yaml")
-                wandb_logger.experiment.save(f"{callback.dirpath}/data_config.yaml", callback.dirpath)
+                wandb_logger.experiment.save(
+                    f"{callback.dirpath}/data_config.yaml", callback.dirpath
+                )
                 wandb_logger.experiment.save("./experiment_config.yaml")
 
                 break

--- a/pvnet/training.py
+++ b/pvnet/training.py
@@ -123,11 +123,9 @@ def train(config: DictConfig) -> Optional[float]:
                 shutil.copyfile(data_config, f"{callback.dirpath}/data_config.yaml")
 
                 # upload configuration up to wandb
-                os.makedirs("./configuration", exist_ok=True)
-                shutil.copyfile(data_config, f"./configuration/data_config.yaml")
-                OmegaConf.save(config, f"./configuration/config.yaml")
-                wandb_logger.experiment.save(f"./configuration/data_config.yaml")
-                wandb_logger.experiment.save(f"./configuration/config.yaml")
+                OmegaConf.save(config, f"./experiment_config.yaml")
+                wandb_logger.experiment.save(f"{callback.dirpath}/data_config.yaml", callback.dirpath)
+                wandb_logger.experiment.save(f"./experiment_config.yaml")
 
                 break
 

--- a/pvnet/training.py
+++ b/pvnet/training.py
@@ -121,6 +121,14 @@ def train(config: DictConfig) -> Optional[float]:
 
                 assert os.path.isfile(data_config), f"Data config file not found: {data_config}"
                 shutil.copyfile(data_config, f"{callback.dirpath}/data_config.yaml")
+
+                # upload configuration up to wandb
+                os.makedirs("./configuration", exist_ok=True)
+                shutil.copyfile(data_config, f"./configuration/data_config.yaml")
+                OmegaConf.save(config, f"./configuration/config.yaml")
+                wandb_logger.experiment.save(f"./configuration/data_config.yaml")
+                wandb_logger.experiment.save(f"./configuration/config.yaml")
+
                 break
 
     should_pretrain = False


### PR DESCRIPTION
# Pull Request

## Description

- save configruation, 
- hydra and wandb should save it, but there is an issue with `_target_` dicts, and tricky to find out where the error was. Easier to save the file directly

#168 

## How Has This Been Tested?

Ran it locally

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
