### PR TITLE
Use concurrent batch pipeline for ~30x speed up

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -94,7 +94,7 @@ def minimize_data_config(input_path, output_path, model):
         if not model.include_nwp:
             del config["input_data"]["nwp"]
         else:
-            for nwp_source in list(config["input_data"]["nwp"].keys()):
+            for nwp_source in config["input_data"]["nwp"].keys():
                 nwp_config = config["input_data"]["nwp"][nwp_source]
 
                 if nwp_source not in model.nwp_encoders_dict:

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -94,7 +94,7 @@ def minimize_data_config(input_path, output_path, model):
         if not model.include_nwp:
             del config["input_data"]["nwp"]
         else:
-            for nwp_source in config["input_data"]["nwp"].keys():
+            for nwp_source in list(config["input_data"]["nwp"].keys()):
                 nwp_config = config["input_data"]["nwp"][nwp_source]
 
                 if nwp_source not in model.nwp_encoders_dict:

--- a/scripts/backtest_uk_gsp.py
+++ b/scripts/backtest_uk_gsp.py
@@ -139,7 +139,7 @@ def get_available_t0_times(start_datetime, end_datetime, config_path):
     # Pop out the config file
     config = datapipes_dict.pop("config")
 
-    # We are going to abuse the `create_datapipes()` function to find the init-times in
+    # We are going to abuse the `create_t0_datapipe()` function to find the init-times in
     # potential_init_times which we have input data for. To do this, we will feed in some fake GSP
     # data which has the potential_init_times as timestamps. This is a bit hacky but works for now
 

--- a/scripts/backtest_uk_gsp.py
+++ b/scripts/backtest_uk_gsp.py
@@ -196,10 +196,6 @@ def get_times_datapipe(config_path):
         Datapipe: A Datapipe yielding init-times
     """
 
-    # Set up ID location query object
-    ds_gsp = get_gsp_ds(config_path)
-    GSPLocationLookup(ds_gsp.x_osgb, ds_gsp.y_osgb)
-
     # Filter the init-times to times we have all input data for
     available_target_times = get_available_t0_times(
         start_datetime,

--- a/scripts/backtest_uk_gsp.py
+++ b/scripts/backtest_uk_gsp.py
@@ -168,7 +168,7 @@ def get_available_t0_times(start_datetime, end_datetime, config_path):
     # Overwrite the GSP data which is already in the datapipes dict
     datapipes_dict["gsp"] = IterableWrapper([ds_fake_gsp])
 
-    # Use create_t0_and_loc_datapipes to get datapipe of init-times
+    # Use create_t0_datapipe to get datapipe of init-times
     t0_datapipe = create_t0_datapipe(
         datapipes_dict,
         configuration=config,

--- a/scripts/backtest_uk_gsp.py
+++ b/scripts/backtest_uk_gsp.py
@@ -38,14 +38,11 @@ from ocf_datapipes.batch import (
     NumpyBatch,
     batch_to_tensor,
     copy_batch_to_device,
-    stack_np_examples_into_batch,
 )
 from ocf_datapipes.config.load import load_yaml_configuration
 from ocf_datapipes.load import OpenGSP
-from ocf_datapipes.training.pvnet_all_gsp import (
-    create_t0_datapipe, construct_sliced_data_pipeline
-)
 from ocf_datapipes.training.common import _get_datapipes_dict
+from ocf_datapipes.training.pvnet_all_gsp import construct_sliced_data_pipeline, create_t0_datapipe
 from ocf_datapipes.utils.consts import ELEVATION_MEAN, ELEVATION_STD
 from omegaconf import DictConfig
 
@@ -201,7 +198,7 @@ def get_times_datapipe(config_path):
 
     # Set up ID location query object
     ds_gsp = get_gsp_ds(config_path)
-    gsp_id_to_loc = GSPLocationLookup(ds_gsp.x_osgb, ds_gsp.y_osgb)
+    GSPLocationLookup(ds_gsp.x_osgb, ds_gsp.y_osgb)
 
     # Filter the init-times to times we have all input data for
     available_target_times = get_available_t0_times(
@@ -367,7 +364,6 @@ def get_datapipe(config_path: str) -> NumpyBatch:
 
     # Convert to tensor for model
     data_pipeline = data_pipeline.map(batch_to_tensor).set_length(len(t0_datapipe))
-
 
     return data_pipeline
 

--- a/scripts/save_concurrent_batches.py
+++ b/scripts/save_concurrent_batches.py
@@ -32,19 +32,16 @@ import warnings
 import hydra
 import numpy as np
 import torch
-from ocf_datapipes.batch import BatchKey, batch_to_tensor, stack_np_examples_into_batch
-from ocf_datapipes.training.common import (
-    open_and_return_datapipes,
-)
+from ocf_datapipes.batch import BatchKey
 from ocf_datapipes.training.pvnet_all_gsp import (
-    construct_time_pipeline, construct_sliced_data_pipeline
+    construct_sliced_data_pipeline,
+    construct_time_pipeline,
 )
 from omegaconf import DictConfig, OmegaConf
 from sqlalchemy import exc as sa_exc
 from torch.utils.data import DataLoader
 from torch.utils.data.datapipes.iter import IterableWrapper
 from tqdm import tqdm
-
 
 warnings.filterwarnings("ignore", category=sa_exc.SAWarning)
 
@@ -63,7 +60,6 @@ class _save_batch_func_factory:
 
 
 def _get_datapipe(config_path, start_time, end_time, n_batches):
-
     t0_datapipe = construct_time_pipeline(
         config_path,
         start_time,
@@ -72,7 +68,7 @@ def _get_datapipe(config_path, start_time, end_time, n_batches):
 
     t0_datapipe = t0_datapipe.header(n_batches)
     t0_datapipe = t0_datapipe.sharding_filter()
-    
+
     datapipe = construct_sliced_data_pipeline(
         config_path,
         t0_datapipe,

--- a/scripts/save_concurrent_batches.py
+++ b/scripts/save_concurrent_batches.py
@@ -32,7 +32,7 @@ import warnings
 import hydra
 import numpy as np
 import torch
-from ocf_datapipes.batch import BatchKey
+from ocf_datapipes.batch import BatchKey, batch_to_tensor
 from ocf_datapipes.training.pvnet_all_gsp import (
     construct_sliced_data_pipeline,
     construct_time_pipeline,
@@ -72,7 +72,7 @@ def _get_datapipe(config_path, start_time, end_time, n_batches):
     datapipe = construct_sliced_data_pipeline(
         config_path,
         t0_datapipe,
-    )
+    ).map(batch_to_tensor)
 
     return datapipe
 


### PR DESCRIPTION
Add the PVNet concurrent datapipe to the concurrent batch creation and backtest scripts. The new data is already in `ocf_datapipes` and is about 30x faster than the old datapipe for creating concurrent batches