### PR TITLE
Update default for wandb_ids

### DIFF
--- a/scripts/checkpoint_to_huggingface.py
+++ b/scripts/checkpoint_to_huggingface.py
@@ -21,7 +21,7 @@ huggingface_repo = "openclimatefix/pvnet_uk_region"
 def push_to_huggingface(
     checkpoint_dir_paths: list[str],
     val_best: bool = True,
-    wandb_ids: Optional[list[str]] = None,
+    wandb_ids: list[str] = [],
     local_path: Optional[str] = None,
     push_to_hub: bool = True,
 ):


### PR DESCRIPTION
# Pull Request

## Description

Have run into this a couple times now where I have ran the script with just the `checkpoint_dir_path` parameter and I got an error about the `wandb_ids` being None, I realised it didn't go into the logic to get the run ID starting at line 43 since that checks if it is an empty list and the default is None and then runs into an error if it's not an ensemble due to

```
if not is_ensemble:
        wandb_ids = wandb_ids[0]
```

so I think changing it's default to an empty list might work a little more smoothly 