### PR TITLE
Fix history bug and add bells in analysis.py

### DIFF
--- a/experiments/analysis.py
+++ b/experiments/analysis.py
@@ -16,10 +16,11 @@ def main(runs: list[str], run_names: list[str]) -> None:
     """
     api = wandb.Api()
     dfs = []
+    epoch_num = []
     for run in runs:
-        run = api.run(f"openclimatefix/india/{run}")
+        run = api.run(f"openclimatefix/PROJECT/{run}")
 
-        df = run.history()
+        df = run.history(samples=run.lastHistoryStep+1)
         # Get the columns that are in the format 'MAE_horizon/step_<number>/val`
         mae_cols = [col for col in df.columns if "MAE_horizon/step_" in col and "val" in col]
         # Sort them
@@ -40,6 +41,7 @@ def main(runs: list[str], run_names: list[str]) -> None:
         # Get the step from the column name
         column_timesteps = [int(col.split("_")[-1].split("/")[0]) * 15 for col in mae_cols]
         dfs.append(df)
+        epoch_num.append(min_row_idx)
     # Get the timedelta for each group
     groupings = [
         [0, 0],
@@ -89,22 +91,22 @@ def main(runs: list[str], run_names: list[str]) -> None:
     # Plot the error on per timestep, and all timesteps
     plt.figure()
     for idx, df in enumerate(dfs):
-        plt.plot(column_timesteps, df, label=run_names[idx])
-    plt.legend()
-    plt.xlabel("Timestep (minutes)")
-    plt.ylabel("MAE %")
-    plt.title("MAE % for each timestep")
+        plt.plot(column_timesteps, df, label=f"{run_names[idx]}, epoch: {epoch_num[idx]}")
+    plt.legend(fontsize=18)
+    plt.xlabel("Timestep (minutes)", fontsize=18)
+    plt.ylabel("MAE %", fontsize=18)
+    plt.title("MAE % for each timestep", fontsize=24)
     plt.savefig("mae_per_timestep.png")
     plt.show()
 
     # Plot the error on per timestep, and grouped timesteps
     plt.figure()
-    for run_name in run_names:
-        plt.plot(groups_df[run_name], label=run_name)
-    plt.legend()
-    plt.xlabel("Timestep (minutes)")
-    plt.ylabel("MAE %")
-    plt.title("MAE % for each timestep")
+    for idx, run_name in enumerate(run_names):
+        plt.plot(groups_df[run_name], label=f"{run_name}, epoch: {epoch_num[idx]}")
+    plt.legend(fontsize=18)
+    plt.xlabel("Timestep (minutes)", fontsize=18)
+    plt.ylabel("MAE %", fontsize=18)
+    plt.title("MAE % for each timestep", fontsize=24)
     plt.savefig("mae_per_timestep.png")
     plt.show()
 
@@ -119,3 +121,4 @@ if __name__ == "__main__":
     parser.add_argument("--run_names", nargs="+")
     args = parser.parse_args()
     main(args.list_of_runs, args.run_names)
+    

--- a/experiments/analysis.py
+++ b/experiments/analysis.py
@@ -92,10 +92,10 @@ def main(runs: list[str], run_names: list[str]) -> None:
     plt.figure()
     for idx, df in enumerate(dfs):
         plt.plot(column_timesteps, df, label=f"{run_names[idx]}, epoch: {epoch_num[idx]}")
-    plt.legend(fontsize=18)
-    plt.xlabel("Timestep (minutes)", fontsize=18)
-    plt.ylabel("MAE %", fontsize=18)
-    plt.title("MAE % for each timestep", fontsize=24)
+    plt.legend()
+    plt.xlabel("Timestep (minutes)")
+    plt.ylabel("MAE %")
+    plt.title("MAE % for each timestep")
     plt.savefig("mae_per_timestep.png")
     plt.show()
 
@@ -103,10 +103,10 @@ def main(runs: list[str], run_names: list[str]) -> None:
     plt.figure()
     for idx, run_name in enumerate(run_names):
         plt.plot(groups_df[run_name], label=f"{run_name}, epoch: {epoch_num[idx]}")
-    plt.legend(fontsize=18)
-    plt.xlabel("Timestep (minutes)", fontsize=18)
-    plt.ylabel("MAE %", fontsize=18)
-    plt.title("MAE % for each timestep", fontsize=24)
+    plt.legend()
+    plt.xlabel("Timestep (minutes)")
+    plt.ylabel("MAE %")
+    plt.title("MAE % for each timestep")
     plt.savefig("mae_per_timestep.png")
     plt.show()
 

--- a/experiments/analysis.py
+++ b/experiments/analysis.py
@@ -20,7 +20,7 @@ def main(runs: list[str], run_names: list[str]) -> None:
     for run in runs:
         run = api.run(f"openclimatefix/PROJECT/{run}")
 
-        df = run.history(samples=run.lastHistoryStep+1)
+        df = run.history(samples=run.lastHistoryStep + 1)
         # Get the columns that are in the format 'MAE_horizon/step_<number>/val`
         mae_cols = [col for col in df.columns if "MAE_horizon/step_" in col and "val" in col]
         # Sort them
@@ -121,4 +121,3 @@ if __name__ == "__main__":
     parser.add_argument("--run_names", nargs="+")
     args = parser.parse_args()
     main(args.list_of_runs, args.run_names)
-    


### PR DESCRIPTION
# Pull Request

## Description
Analysis.py results were inconsistent because `run.history()` was pulling 500 random steps instead of the whole history. Fixed that.

Bells and whistles:
- Added epoch number to the legend label for easier assessment. May be redundant, happy to remove it

## How Has This Been Tested?
Ran analysis.py several times for the same set of runs to make sure it gave consistent results; separately tested that run.lastHistoryStep was working as expected

- [X] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
