### PR TITLE
save validation batch results to wandb

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -635,7 +635,11 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
 
         for i in range(batch_size):
             y_i = y[i]
-            y_hat_i = y_hat[i]
+            if self.use_quantile_regression:
+                idx = self.output_quantiles.index(0.5)
+                y_hat_i = y_hat[i,idx]
+            else:
+                y_hat_i = y_hat[i]
             time_utc_i = time_utc[i]
             target_id_i = target_id[i]
 

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -617,7 +617,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         """Append validation results to self.validation_epoch_results"""
 
         # get truth values, shape (b, forecast_len)
-        y = batch[self._target_key][:, -self.forecast_len:, 0]
+        y = batch[self._target_key][:, -self.forecast_len :, 0]
         y = y.detach().cpu().numpy()
         batch_size = y.shape[0]
 
@@ -626,7 +626,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
 
         # get time_utc, shape (b, forecast_len)
         time_utc_key = BatchKey[f"{self._target_key_name}_time_utc"]
-        time_utc = batch[time_utc_key][:, -self.forecast_len:].detach().cpu().numpy()
+        time_utc = batch[time_utc_key][:, -self.forecast_len :].detach().cpu().numpy()
 
         # get target id and change from (b,1) to (b,)
         id_key = BatchKey[f"{self._target_key_name}_id"]

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -623,18 +623,13 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
             y_i = y[i].detach().cpu().numpy()
             y_hat_i = y_hat[i].detach().cpu().numpy()
 
-            print(BatchKey._member_map_)
-            try:
-                time_utc_key = BatchKey[f"{self._target_key}_time_utc"]
-            except Exception as e:
-                raise Exception(
-                    f"Failed to find time_utc key for {self._target_key}, {BatchKey._member_map_}, {e}"
-                )
-
+            time_utc_key = BatchKey[f"{self._target_key_name}_time_utc"]
             time_utc = batch[time_utc_key][i, -self.forecast_len :].detach().cpu().numpy()
 
-            id_key = BatchKey[f"{self._target_key}_id"]
+            id_key = BatchKey[f"{self._target_key_name}_id"]
             target_id = batch[id_key][i].detach().cpu().numpy()
+            if target_id.ndim > 0:
+                target_id = target_id[0]
 
             results_df = pd.DataFrame(
                 {

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -1,8 +1,8 @@
 """Base model for all PVNet submodels"""
 import json
 import logging
-import tempfile
 import os
+import tempfile
 from pathlib import Path
 from typing import Dict, Optional, Union
 
@@ -614,9 +614,9 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         plt.close(fig)
 
     def _log_validation_results(self, batch, y_hat, accum_batch_num):
-        """ Append validation results to self.validation_epoch_results """
+        """Append validation results to self.validation_epoch_results"""
 
-        y = batch[self._target_key][:, -self.forecast_len:, 0]
+        y = batch[self._target_key][:, -self.forecast_len :, 0]
         batch_size = y.shape[0]
 
         for i in range(batch_size):
@@ -624,18 +624,21 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
             y_hat_i = y_hat[i].detach().cpu().numpy()
 
             time_utc_key = BatchKey[f"{self._target_key}_time_utc"]
-            time_utc = batch[time_utc_key][i, -self.forecast_len:].detach().cpu().numpy()
+            time_utc = batch[time_utc_key][i, -self.forecast_len :].detach().cpu().numpy()
 
             id_key = BatchKey[f"{self._target_key}_id"]
             ids = batch[id_key][i].detach().cpu().numpy()
 
-            self.validation_epoch_results.append({"y": y_i,
-                                                  "y_hat": y_hat_i,
-                                                  "time_utc": time_utc,
-                                                  "id": ids,
-                                                  "batch_idx": accum_batch_num,
-                                                  "example_idx": i,
-                                                  })
+            self.validation_epoch_results.append(
+                {
+                    "y": y_i,
+                    "y_hat": y_hat_i,
+                    "time_utc": time_utc,
+                    "id": ids,
+                    "batch_idx": accum_batch_num,
+                    "example_idx": i,
+                }
+            )
 
     def validation_step(self, batch: dict, batch_idx):
         """Run validation step"""
@@ -713,7 +716,9 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
                 filename = os.path.join(tempdir, f"validation_results.csv_{self.current_epoch}")
                 validation_results_df.to_csv(filename, index=False)
 
-                validation_artifact = wandb.Artifact(f"validation_results_epoch={self.current_epoch}", type="dataset")
+                validation_artifact = wandb.Artifact(
+                    f"validation_results_epoch={self.current_epoch}", type="dataset"
+                )
                 wandb.log_artifact(validation_artifact)
         except Exception as e:
             print("Failed to log validation results to wandb")

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -621,7 +621,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         y = y.detach().cpu().numpy()
         batch_size = y.shape[0]
 
-        # get truth values, shape (b, forecast_len)
+        # get prediction values, shape (b, forecast_len, quantiles?)
         y_hat = y_hat.detach().cpu().numpy()
 
         # get time_utc, shape (b, forecast_len)

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -623,10 +623,10 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
             y_i = y[i].detach().cpu().numpy()
             y_hat_i = y_hat[i].detach().cpu().numpy()
 
-            time_utc_key = getattr(BatchKey, f"{self._target_key}_time_utc")
+            time_utc_key = BatchKey[f"{self._target_key}_time_utc"]
             time_utc = batch[time_utc_key][i, -self.forecast_len :].detach().cpu().numpy()
 
-            id_key = getattr(BatchKey, f"{self._target_key}_id")
+            id_key = BatchKey[f"{self._target_key}_id"]
             target_id = batch[id_key][i].detach().cpu().numpy()
 
             results_df = pd.DataFrame(

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -636,9 +636,9 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
                     "time_utc": time_utc,
                 }
             )
-            results_df['id'] = target_id
-            results_df['batch_idx'] = accum_batch_num
-            results_df['example_idx'] = i
+            results_df["id"] = target_id
+            results_df["batch_idx"] = accum_batch_num
+            results_df["example_idx"] = i
 
             self.validation_epoch_results.append(results_df)
 

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -624,8 +624,11 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
             y_hat_i = y_hat[i].detach().cpu().numpy()
 
             print(BatchKey._member_map_)
+            try:
+                time_utc_key = BatchKey[f"{self._target_key}_time_utc"]
+            except Exception as e:
+                raise Exception(f"Failed to find time_utc key for {self._target_key}, {BatchKey._member_map_}, {e}")
 
-            time_utc_key = BatchKey[f"{self._target_key}_time_utc"]
             time_utc = batch[time_utc_key][i, -self.forecast_len :].detach().cpu().numpy()
 
             id_key = BatchKey[f"{self._target_key}_id"]

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -627,7 +627,9 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
             try:
                 time_utc_key = BatchKey[f"{self._target_key}_time_utc"]
             except Exception as e:
-                raise Exception(f"Failed to find time_utc key for {self._target_key}, {BatchKey._member_map_}, {e}")
+                raise Exception(
+                    f"Failed to find time_utc key for {self._target_key}, {BatchKey._member_map_}, {e}"
+                )
 
             time_utc = batch[time_utc_key][i, -self.forecast_len :].detach().cpu().numpy()
 

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -623,6 +623,8 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
             y_i = y[i].detach().cpu().numpy()
             y_hat_i = y_hat[i].detach().cpu().numpy()
 
+            print(BatchKey._member_map_)
+
             time_utc_key = BatchKey[f"{self._target_key}_time_utc"]
             time_utc = batch[time_utc_key][i, -self.forecast_len :].detach().cpu().numpy()
 


### PR DESCRIPTION
# Pull Request

## Description

Save csv of validation results to weights and biases

This is done by 
- results being appended each validation step,
- saved all together at the end of the validation step 

## How Has This Been Tested?

CI tests
- local test with script

```python
import wandb
import pandas as pd

run = wandb.init(
    project="test",
    notes="My first experiment",
)

# make random dataframe
df = pd.DataFrame({
    "a": [1, 2, 3],
    "b": [4, 5, 6]
})

i=2
validation_artifact = wandb.Artifact(f"validation_results_{i}", type="dataset")
df.to_csv(f"validation_results_{i}.csv", index=False)
validation_artifact.add_file(f"validation_results_{i}.csv")
wandb.log_artifact(validation_artifact)

```
 
![Screenshot 2024-09-05 at 16 15 28](https://github.com/user-attachments/assets/6a849c94-2abf-4d91-81dd-2f2dcc882f54)

- [ ] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
