### PR TITLE
Fix wandb artifact saving in base_model.py

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -735,7 +735,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
 
                 # make and log wand artifact
                 validation_artifact = wandb.Artifact(
-                    f"validation_results_epoch={self.current_epoch}", type="dataset"
+                    f"validation_results_epoch_{self.current_epoch}", type="dataset"
                 )
                 validation_artifact.add_file(filename)
                 wandb.log_artifact(validation_artifact)


### PR DESCRIPTION
# Pull Request

## Description

Changed val results artifact name for wandb to not contain restricted characters. Otherwise was getting this error:
```
Artifact name may only contain alphanumeric characters, dashes, underscores, and dots. Invalid name: validation_results_epoch=0
```

## How Has This Been Tested?

Ran training with the fix and synced the result to wandb, now the artifacts get saved

- [X] Yes


## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
