### PR TITLE
add flushing of val epoch resluts

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -666,7 +666,8 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         # Sensor seems to be in batch, station, time order
         y = batch[self._target_key][:, -self.forecast_len :, 0]
 
-        self._log_validation_results(batch, y_hat, accum_batch_num)
+        if (batch_idx + 1) % self.trainer.accumulate_grad_batches == 0:
+            self._log_validation_results(batch, y_hat, accum_batch_num)
 
         # Expand persistence to be the same shape as y
         losses = self._calculate_common_losses(y, y_hat)

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -1,4 +1,3 @@
-"""Base model for all PVNet submodels"""
 import json
 import logging
 import os
@@ -743,6 +742,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
             print("Failed to log validation results to wandb")
             print(e)
 
+        self.validation_epoch_results = []
         horizon_maes_dict = self._horizon_maes.flush()
 
         # Create the horizon accuracy curve

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -1,3 +1,4 @@
+"""Base model for all PVNet submodels"""
 import json
 import logging
 import os


### PR DESCRIPTION
# Pull Request

## Description

array that stores inference results for wandb csv saving was not getting cleaned between val epochs, resulting in blowing up file sizes. Added removing results after logging.

Potentially fixes #255 as the files will be kept to 19-20 MB (for me at least; obviously will be different for different configs, this is 3 quantiles and 32 points predictions) instead of getting to 240+MB by epoch 11 etc. (Still need to remove keeping multiple versions of one artifact, not sure how to do that yet)

## How Has This Been Tested?
Run training for 3 epochs, checked resulting csvs had expected sizes and contents

- [X] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
