### PR TITLE
add pv padding and hf model handling to backtest_sites.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "xarray",
     "ipykernel",
     "h5netcdf",
-    "torch>=2.0.0, <2.5.0",
+    "torch>=2.0.0",
     "lightning",
     "torchvision",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "xarray",
     "ipykernel",
     "h5netcdf",
-    "torch>=2.0.0",
+    "torch>=2.0.0, <2.5.0",
     "lightning",
     "torchvision",
     "pytest",

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -70,9 +70,9 @@ output_dir = "PLACEHOLDER"
 # checkpoint on the val set
 model_chckpoint_dir = "PLACEHOLDER"
 
-revision = None
-token = None
-model_id = None
+hf_revision = None
+hf_token = None
+hf_model_id = None
 
 # Forecasts will be made for all available init times between these
 start_datetime = "2022-05-08 00:00"
@@ -477,9 +477,9 @@ def main(config: DictConfig):
     # Create a dataloader for the concurrent batches and use multiprocessing
     dataloader = DataLoader(batch_pipe, **dataloader_kwargs)
     # Load the PVNet model
-    if model_chckpoint_dir is not None:
+    if model_chckpoint_dir:
         model, *_ = get_model_from_checkpoints([model_chckpoint_dir], val_best=True)
-    elif model_id is not None:
+    elif model_id:
         model = load_model_from_hf(model_id, revision, token)
     else:
         raise ValueError("Provide a model checkpoint or a HuggingFace model")

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -111,8 +111,8 @@ ALL_SITE_IDS.sort()
 @functional_datapipe("pad_forward_pv")
 class PadForwardPVIterDataPipe(IterDataPipe):
     """
-    Pads forecast pv. 
-    
+    Pads forecast pv.
+
     Sun position is calculated based off of pv time index
     and for t0's close to end of pv data can have wrong shape as pv starts
     to run out of data to slice for the forecast part.

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -137,7 +137,6 @@ class PadForwardPVIterDataPipe(IterDataPipe):
 
 
 def load_model_from_hf(model_id: str, revision: str, token: str):
-
     """
     Loads model from HuggingFace
     """

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -479,8 +479,8 @@ def main(config: DictConfig):
     # Load the PVNet model
     if model_chckpoint_dir:
         model, *_ = get_model_from_checkpoints([model_chckpoint_dir], val_best=True)
-    elif model_id:
-        model = load_model_from_hf(model_id, revision, token)
+    elif hf_model_id:
+        model = load_model_from_hf(hf_model_id, hf_revision, hf_token)
     else:
         raise ValueError("Provide a model checkpoint or a HuggingFace model")
 

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -23,6 +23,7 @@ try:
 except RuntimeError:
     pass
 
+import json
 import logging
 import os
 import sys
@@ -32,6 +33,8 @@ import numpy as np
 import pandas as pd
 import torch
 import xarray as xr
+from huggingface_hub import hf_hub_download
+from huggingface_hub.constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from ocf_datapipes.batch import (
     BatchKey,
     NumpyBatch,
@@ -56,10 +59,6 @@ from tqdm import tqdm
 
 from pvnet.load_model import get_model_from_checkpoints
 from pvnet.utils import SiteLocationLookup
-
-import json
-from huggingface_hub import hf_hub_download
-from huggingface_hub.constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 
 # ------------------------------------------------------------------
 # USER CONFIGURED VARIABLES TO RUN THE SCRIPT
@@ -109,7 +108,7 @@ ALL_SITE_IDS.sort()
 # FUNCTIONS
 
 
-@functional_datapipe('pad_forward_pv')
+@functional_datapipe("pad_forward_pv")
 class PadForwardPVIterDataPipe(IterDataPipe):
     """
     Pads forecast pv. Sun position is calculated based off of pv time index
@@ -128,8 +127,8 @@ class PadForwardPVIterDataPipe(IterDataPipe):
         """Iter"""
 
         for xr_data in self.pv_dp:
-            t0 = xr_data.time_utc.data[int(xr_data.attrs['t0_idx'])]
-            pv_step = np.timedelta64(xr_data.attrs['sample_period_duration'])
+            t0 = xr_data.time_utc.data[int(xr_data.attrs["t0_idx"])]
+            pv_step = np.timedelta64(xr_data.attrs["sample_period_duration"])
             t_end = t0 + self.forecast_duration + pv_step
             time_idx = np.arange(xr_data.time_utc.data[0], t_end, pv_step)
             yield xr_data.reindex(time_utc=time_idx, fill_value=-1)
@@ -424,8 +423,8 @@ def get_datapipe(config_path: str) -> NumpyBatch:
     )
 
     config = load_yaml_configuration(config_path)
-    data_pipeline['pv'] = data_pipeline['pv'].pad_forward_pv(
-        forecast_duration=np.timedelta64(config.input_data.pv.forecast_minutes, 'm')
+    data_pipeline["pv"] = data_pipeline["pv"].pad_forward_pv(
+        forecast_duration=np.timedelta64(config.input_data.pv.forecast_minutes, "m")
     )
 
     data_pipeline = DictDatasetIterDataPipe(

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -111,7 +111,9 @@ ALL_SITE_IDS.sort()
 @functional_datapipe("pad_forward_pv")
 class PadForwardPVIterDataPipe(IterDataPipe):
     """
-    Pads forecast pv. Sun position is calculated based off of pv time index
+    Pads forecast pv. 
+    
+    Sun position is calculated based off of pv time index
     and for t0's close to end of pv data can have wrong shape as pv starts
     to run out of data to slice for the forecast part.
     """
@@ -135,6 +137,10 @@ class PadForwardPVIterDataPipe(IterDataPipe):
 
 
 def load_model_from_hf(model_id: str, revision: str, token: str):
+
+"""
+Loads model from HuggingFace
+"""
     model_file = hf_hub_download(
         repo_id=model_id,
         filename=PYTORCH_WEIGHTS_NAME,

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -141,6 +141,7 @@ def load_model_from_hf(model_id: str, revision: str, token: str):
 """
 Loads model from HuggingFace
 """
+
     model_file = hf_hub_download(
         repo_id=model_id,
         filename=PYTORCH_WEIGHTS_NAME,

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -50,12 +50,16 @@ from ocf_datapipes.training.pvnet_site import (
 )
 from ocf_datapipes.utils.consts import ELEVATION_MEAN, ELEVATION_STD
 from omegaconf import DictConfig
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, IterDataPipe, functional_datapipe
 from torch.utils.data.datapipes.iter import IterableWrapper
 from tqdm import tqdm
 
 from pvnet.load_model import get_model_from_checkpoints
 from pvnet.utils import SiteLocationLookup
+
+import json
+from huggingface_hub import hf_hub_download
+from huggingface_hub.constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 
 # ------------------------------------------------------------------
 # USER CONFIGURED VARIABLES TO RUN THE SCRIPT
@@ -66,6 +70,10 @@ output_dir = "PLACEHOLDER"
 # Local directory to load the PVNet checkpoint from. By default this should pull the best performing
 # checkpoint on the val set
 model_chckpoint_dir = "PLACEHOLDER"
+
+revision = None
+token = None
+model_id = None
 
 # Forecasts will be made for all available init times between these
 start_datetime = "2022-05-08 00:00"
@@ -101,11 +109,64 @@ ALL_SITE_IDS.sort()
 # FUNCTIONS
 
 
+@functional_datapipe('pad_forward_pv')
+class PadForwardPVIterDataPipe(IterDataPipe):
+    """
+    Pads forecast pv. Sun position is calculated based off of pv time index
+    and for t0's close to end of pv data can have wrong shape as pv starts
+    to run out of data to slice for the forecast part.
+    """
+
+    def __init__(self, pv_dp: IterDataPipe, forecast_duration: np.timedelta64):
+        """Init"""
+
+        super().__init__()
+        self.pv_dp = pv_dp
+        self.forecast_duration = forecast_duration
+
+    def __iter__(self):
+        """Iter"""
+
+        for xr_data in self.pv_dp:
+            t0 = xr_data.time_utc.data[int(xr_data.attrs['t0_idx'])]
+            pv_step = np.timedelta64(xr_data.attrs['sample_period_duration'])
+            t_end = t0 + self.forecast_duration + pv_step
+            time_idx = np.arange(xr_data.time_utc.data[0], t_end, pv_step)
+            yield xr_data.reindex(time_utc=time_idx, fill_value=-1)
+
+
+def load_model_from_hf(model_id: str, revision: str, token: str):
+    model_file = hf_hub_download(
+        repo_id=model_id,
+        filename=PYTORCH_WEIGHTS_NAME,
+        revision=revision,
+        token=token,
+    )
+
+    # load config file
+    config_file = hf_hub_download(
+        repo_id=model_id,
+        filename=CONFIG_NAME,
+        revision=revision,
+        token=token,
+    )
+
+    with open(config_file, "r", encoding="utf-8") as f:
+        config = json.load(f)
+
+    model = hydra.utils.instantiate(config)
+
+    state_dict = torch.load(model_file, map_location=torch.device("cuda"))
+    model.load_state_dict(state_dict)  # type: ignore
+    model.eval()  # type: ignore
+
+    return model
+
+
 def preds_to_dataarray(preds, model, valid_times, site_ids):
     """Put numpy array of predictions into a dataarray"""
 
     if model.use_quantile_regression:
-        output_labels = model.output_quantiles
         output_labels = [f"forecast_mw_plevel_{int(q*100):02}" for q in model.output_quantiles]
         output_labels[output_labels.index("forecast_mw_plevel_50")] = "forecast_mw"
     else:
@@ -333,7 +394,7 @@ class ModelPipe:
         da_abs_site = da_abs_site.where(~da_sundown_mask).fillna(0.0)
 
         da_abs_site = da_abs_site.expand_dims(dim="init_time_utc", axis=0).assign_coords(
-            init_time_utc=[t0]
+            init_time_utc=np.array([t0], dtype="datetime64[ns]")
         )
 
         return da_abs_site
@@ -360,6 +421,11 @@ def get_datapipe(config_path: str) -> NumpyBatch:
         config_path,
         location_pipe,
         t0_datapipe,
+    )
+
+    config = load_yaml_configuration(config_path)
+    data_pipeline['pv'] = data_pipeline['pv'].pad_forward_pv(
+        forecast_duration=np.timedelta64(config.input_data.pv.forecast_minutes, 'm')
     )
 
     data_pipeline = DictDatasetIterDataPipe(
@@ -412,7 +478,13 @@ def main(config: DictConfig):
     # Create a dataloader for the concurrent batches and use multiprocessing
     dataloader = DataLoader(batch_pipe, **dataloader_kwargs)
     # Load the PVNet model
-    model, *_ = get_model_from_checkpoints([model_chckpoint_dir], val_best=True)
+    if model_chckpoint_dir is not None:
+        model, *_ = get_model_from_checkpoints([model_chckpoint_dir], val_best=True)
+    elif model_id is not None:
+        model = load_model_from_hf(model_id, revision, token)
+    else:
+        raise ValueError("Provide a model checkpoint or a HuggingFace model")
+
     model = model.eval().to(device)
 
     # Create object to make predictions for each input batch
@@ -426,13 +498,13 @@ def main(config: DictConfig):
 
             t0 = ds_abs_all.init_time_utc.values[0]
 
-            # Save the predictioons
+            # Save the predictions
             filename = f"{output_dir}/{t0}.nc"
             ds_abs_all.to_netcdf(filename)
 
             pbar.update()
         except Exception as e:
-            print(f"Exception {e} at {i}")
+            print(f"Exception {e} at batch {i}")
             pass
 
     # Close down

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -138,9 +138,9 @@ class PadForwardPVIterDataPipe(IterDataPipe):
 
 def load_model_from_hf(model_id: str, revision: str, token: str):
 
-"""
-Loads model from HuggingFace
-"""
+    """
+    Loads model from HuggingFace
+    """
 
     model_file = hf_hub_download(
         repo_id=model_id,


### PR DESCRIPTION
# Pull Request

## Description

- Added an option to use a model from HuggingFace
- Added datapipe to pad pv data so that sun position is created correctly ([see this issue in dpipes](https://github.com/openclimatefix/ocf-data-sampler/issues/67))
- Fixed conversion to nanoseconds warning


## How Has This Been Tested?

Ran small backtest sthat require pv padding with a local and a HF model

- [X] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

Checked that with new coded padding the forecast is identical to what a manually padded dataset produces.

- [X] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
