### PR TITLE
Add ocf colours cycler to mae_analysis

### DIFF
--- a/experiments/mae_analysis.py
+++ b/experiments/mae_analysis.py
@@ -14,7 +14,17 @@ import pandas as pd
 import wandb
 
 matplotlib.rcParams["axes.prop_cycle"] = matplotlib.cycler(
-    color=["FFD053", "7BCDF3", "63BCAF", "086788", "FF9736", "E4E4E4", "14120E", "FFAC5F", "4C9A8E"]
+    color=[
+           "FFD053", # yellow
+           "7BCDF3", # blue
+           "63BCAF", # teal
+           "086788", # dark blue
+           "FF9736", # dark orange
+           "E4E4E4", # grey
+           "14120E", # black
+           "FFAC5F", # orange
+           "4C9A8E", # dark teal
+          ]
 )
 
 

--- a/experiments/mae_analysis.py
+++ b/experiments/mae_analysis.py
@@ -11,6 +11,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import wandb
+import matplotlib
+
+matplotlib.rcParams['axes.prop_cycle'] = matplotlib.cycler(color=[
+    "FFD053", "7BCDF3", "63BCAF", "086788", 
+    "FF9736", "E4E4E4", "14120E", "FFAC5F", "4C9A8E"])
 
 
 def main(project: str, runs: list[str], run_names: list[str]) -> None:

--- a/experiments/mae_analysis.py
+++ b/experiments/mae_analysis.py
@@ -15,16 +15,16 @@ import wandb
 
 matplotlib.rcParams["axes.prop_cycle"] = matplotlib.cycler(
     color=[
-           "FFD053", # yellow
-           "7BCDF3", # blue
-           "63BCAF", # teal
-           "086788", # dark blue
-           "FF9736", # dark orange
-           "E4E4E4", # grey
-           "14120E", # black
-           "FFAC5F", # orange
-           "4C9A8E", # dark teal
-          ]
+        "FFD053",  # yellow
+        "7BCDF3",  # blue
+        "63BCAF",  # teal
+        "086788",  # dark blue
+        "FF9736",  # dark orange
+        "E4E4E4",  # grey
+        "14120E",  # black
+        "FFAC5F",  # orange
+        "4C9A8E",  # dark teal
+    ]
 )
 
 

--- a/experiments/mae_analysis.py
+++ b/experiments/mae_analysis.py
@@ -7,15 +7,15 @@ Does this for 48 hour horizon forecasts with 15 minute granularity
 
 import argparse
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import wandb
-import matplotlib
 
-matplotlib.rcParams['axes.prop_cycle'] = matplotlib.cycler(color=[
-    "FFD053", "7BCDF3", "63BCAF", "086788", 
-    "FF9736", "E4E4E4", "14120E", "FFAC5F", "4C9A8E"])
+matplotlib.rcParams["axes.prop_cycle"] = matplotlib.cycler(
+    color=["FFD053", "7BCDF3", "63BCAF", "086788", "FF9736", "E4E4E4", "14120E", "FFAC5F", "4C9A8E"]
+)
 
 
 def main(project: str, runs: list[str], run_names: list[str]) -> None:


### PR DESCRIPTION
# Pull Request

## Description
Sets colour cycler to ocf colors in mae_analysis.py so it's already on brand if we want to use a plot externally + have a quick reference for the future

Example of plot created w this 
![image](https://github.com/user-attachments/assets/7f611a93-3e91-414f-a131-d4607f9a4775)

I am tempted to remove black and maybe pale colors as well, they look really out of place/hard to distinguish.

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
