### PR TITLE
remove clone depth from ocf-data-sampler install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ here: https://huggingface.co/datasets/openclimatefix/uk_pv
 
 Outside the PVNet repo, clone the ocf-data-sampler repo and exit the conda env created for PVNet: https://github.com/openclimatefix/ocf-data-sampler
 ```bash
-git clone --depth 1 https://github.com/openclimatefix/ocf-data-sampler.git
+git clone https://github.com/openclimatefix/ocf-data-sampler.git
 conda create -n ocf-data-sampler python=3.11
 ```
 
@@ -113,6 +113,8 @@ Then exit this environment, and enter back into the pvnet conda environment and 
 ```bash
 pip install -e <PATH-TO-ocf-data-sampler-REPO>
 ```
+
+If you install the local version of `ocf-data-sampler` that is more recent than the version specified in PVNet, you might receive a warning. However, it should still function correctly.
 
 ## Generating pre-made batches of data for training/validation of PVNet
 


### PR DESCRIPTION
Small update to readme to remove clone depth to avoid tags/versioning not being installed when ocf-data-sampler is cloned and installed as an executable. 

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
