### PR TITLE
Add smart persistence model for solar generation forecasting

### DIFF
--- a/pvnet/models/baseline/readme.md
+++ b/pvnet/models/baseline/readme.md
@@ -2,4 +2,4 @@
 
  - `last_value` - Forecast the sample last historical PV yeild for every forecast step
  - `single_value` - Learns a single value estimate and predicts this value for every input and every
-     forecast step.
+ - `smart_persistence` - A smart persistence model for solar power forecasting that uses historical data and clear sky models to predict future GSP yields.

--- a/pvnet/models/baseline/smart_persistence.py
+++ b/pvnet/models/baseline/smart_persistence.py
@@ -1,17 +1,9 @@
-<<<<<<< HEAD
 """
 Module for the Smart Persistence model.
 
 This module implements a baseline model using smart persistence
 for forecasting global solar power (GSP) yield.
 """
-=======
-from datetime import timedelta
-
-import pandas as pd
-import pvlib
-import torch
->>>>>>> 52d1a52a239f41db089f730771ca0ecd364c7e26
 
 import pvnet
 from pvnet.models.base_model import BaseModel

--- a/pvnet/models/baseline/smart_persistence.py
+++ b/pvnet/models/baseline/smart_persistence.py
@@ -1,3 +1,10 @@
+"""
+Module for the Smart Persistence model.
+
+This module implements a baseline model using smart persistence 
+for forecasting global solar power (GSP) yield.
+"""
+
 import pvnet
 from pvnet.models.base_model import BaseModel
 from pvnet.optimizers import AbstractOptimizer
@@ -6,7 +13,10 @@ import pandas as pd
 from datetime import timedelta
 import torch
 
+
 class Model(BaseModel):
+    """A smart persistence model for solar power forecasting."""
+
     name = "smart_persistence"
 
     def __init__(
@@ -19,6 +29,18 @@ class Model(BaseModel):
         altitude: float = 0.0,
         optimizer: AbstractOptimizer = pvnet.optimizers.Adam(),
     ):
+        """
+        Initialize the SmartPersistence model.
+
+        Args:
+            forecast_minutes (int): Number of minutes to forecast ahead.
+            history_minutes (int): Number of minutes of historical data used.
+            latitude (float): Latitude of the location.
+            longitude (float): Longitude of the location.
+            tz (str): Timezone of the location.
+            altitude (float): Altitude of the location in meters.
+            optimizer (AbstractOptimizer): Optimizer instance for training.
+        """
         super().__init__(history_minutes, forecast_minutes, optimizer)
         self.latitude = latitude
         self.longitude = longitude
@@ -28,12 +50,25 @@ class Model(BaseModel):
         self.save_hyperparameters()
 
     def forward(self, x: dict):
+        """
+        Perform a forward pass to generate a forecast.
+
+        Args:
+            x (dict): Input dictionary containing:
+                - "gsp": Tensor of past GSP yields.
+                - "time": List of timestamps corresponding to the input data.
+
+        Returns:
+            torch.Tensor: Forecasted GSP yield tensor.
+        """
         gsp_yield = x["gsp"]
         gsp_yield = gsp_yield[..., 0]
         y_hat = gsp_yield[:, -self.forecast_len - 1]
         times = x["time"]
         current_time = times[-self.forecast_len - 1]
         current_time_index = pd.DatetimeIndex([current_time])
+
+        
         cs_current = self.location.get_clearsky(current_time_index, model='ineichen')['ghi'].iloc[0]
         forecast_times = pd.DatetimeIndex(
             [current_time + timedelta(minutes=i) for i in range(1, self.forecast_len + 1)]
@@ -43,6 +78,8 @@ class Model(BaseModel):
             k = y_hat / cs_current
         else:
             k = torch.zeros_like(y_hat)
+
         cs_forecast_tensor = torch.tensor(cs_forecast.values, dtype=y_hat.dtype, device=y_hat.device)
         forecast = k.unsqueeze(1) * cs_forecast_tensor.unsqueeze(0)
+
         return forecast

--- a/pvnet/models/baseline/smart_persistence.py
+++ b/pvnet/models/baseline/smart_persistence.py
@@ -1,0 +1,48 @@
+import pvnet
+from pvnet.models.base_model import BaseModel
+from pvnet.optimizers import AbstractOptimizer
+import pvlib
+import pandas as pd
+from datetime import timedelta
+import torch
+
+class Model(BaseModel):
+    name = "smart_persistence"
+
+    def __init__(
+        self,
+        forecast_minutes: int = 12,
+        history_minutes: int = 6,
+        latitude: float = 52.0,
+        longitude: float = 0.1,
+        tz: str = "Etc/UTC",
+        altitude: float = 0.0,
+        optimizer: AbstractOptimizer = pvnet.optimizers.Adam(),
+    ):
+        super().__init__(history_minutes, forecast_minutes, optimizer)
+        self.latitude = latitude
+        self.longitude = longitude
+        self.tz = tz
+        self.altitude = altitude
+        self.location = pvlib.location.Location(latitude, longitude, tz, altitude)
+        self.save_hyperparameters()
+
+    def forward(self, x: dict):
+        gsp_yield = x["gsp"]
+        gsp_yield = gsp_yield[..., 0]
+        y_hat = gsp_yield[:, -self.forecast_len - 1]
+        times = x["time"]
+        current_time = times[-self.forecast_len - 1]
+        current_time_index = pd.DatetimeIndex([current_time])
+        cs_current = self.location.get_clearsky(current_time_index, model='ineichen')['ghi'].iloc[0]
+        forecast_times = pd.DatetimeIndex(
+            [current_time + timedelta(minutes=i) for i in range(1, self.forecast_len + 1)]
+        )
+        cs_forecast = self.location.get_clearsky(forecast_times, model='ineichen')['ghi']
+        if cs_current > 0:
+            k = y_hat / cs_current
+        else:
+            k = torch.zeros_like(y_hat)
+        cs_forecast_tensor = torch.tensor(cs_forecast.values, dtype=y_hat.dtype, device=y_hat.device)
+        forecast = k.unsqueeze(1) * cs_forecast_tensor.unsqueeze(0)
+        return forecast

--- a/pvnet/models/baseline/smart_persistence.py
+++ b/pvnet/models/baseline/smart_persistence.py
@@ -1,14 +1,17 @@
 """
 Module for the Smart Persistence model.
 
-This module implements a baseline model using smart persistence
+This module implements a baseline model using smart persistence 
 for forecasting global solar power (GSP) yield.
 """
 
 import pvnet
 from pvnet.models.base_model import BaseModel
 from pvnet.optimizers import AbstractOptimizer
-
+import pvlib
+import pandas as pd
+from datetime import timedelta
+import torch
 
 
 class Model(BaseModel):
@@ -64,30 +67,21 @@ class Model(BaseModel):
         times = x["time"]
         current_time = times[-self.forecast_len - 1]
         current_time_index = pd.DatetimeIndex([current_time])
-<<<<<<< HEAD
 
-
+        # Compute current and future clear-sky GHI values
         cs_current = self.location.get_clearsky(current_time_index, model='ineichen')['ghi'].iloc[0]
-=======
-        cs_current = self.location.get_clearsky(current_time_index, model="ineichen")["ghi"].iloc[0]
->>>>>>> 52d1a52a239f41db089f730771ca0ecd364c7e26
         forecast_times = pd.DatetimeIndex(
             [current_time + timedelta(minutes=i) for i in range(1, self.forecast_len + 1)]
         )
-        cs_forecast = self.location.get_clearsky(forecast_times, model="ineichen")["ghi"]
+        cs_forecast = self.location.get_clearsky(forecast_times, model='ineichen')['ghi']
+
+        # Compute persistence factor
         if cs_current > 0:
             k = y_hat / cs_current
         else:
             k = torch.zeros_like(y_hat)
-<<<<<<< HEAD
 
         cs_forecast_tensor = torch.tensor(cs_forecast.values, dtype=y_hat.dtype, device=y_hat.device)
         forecast = k.unsqueeze(1) * cs_forecast_tensor.unsqueeze(0)
 
-=======
-        cs_forecast_tensor = torch.tensor(
-            cs_forecast.values, dtype=y_hat.dtype, device=y_hat.device
-        )
-        forecast = k.unsqueeze(1) * cs_forecast_tensor.unsqueeze(0)
->>>>>>> 52d1a52a239f41db089f730771ca0ecd364c7e26
         return forecast

--- a/pvnet/models/baseline/smart_persistence.py
+++ b/pvnet/models/baseline/smart_persistence.py
@@ -1,17 +1,19 @@
 """
 Module for the Smart Persistence model.
 
-This module implements a baseline model using smart persistence 
+This module implements a baseline model using smart persistence
 for forecasting global solar power (GSP) yield.
 """
+
+from datetime import timedelta
+
+import pandas as pd
+import pvlib
+import torch
 
 import pvnet
 from pvnet.models.base_model import BaseModel
 from pvnet.optimizers import AbstractOptimizer
-import pvlib
-import pandas as pd
-from datetime import timedelta
-import torch
 
 
 class Model(BaseModel):
@@ -69,11 +71,11 @@ class Model(BaseModel):
         current_time_index = pd.DatetimeIndex([current_time])
 
         # Compute current and future clear-sky GHI values
-        cs_current = self.location.get_clearsky(current_time_index, model='ineichen')['ghi'].iloc[0]
+        cs_current = self.location.get_clearsky(current_time_index, model="ineichen")["ghi"].iloc[0]
         forecast_times = pd.DatetimeIndex(
             [current_time + timedelta(minutes=i) for i in range(1, self.forecast_len + 1)]
         )
-        cs_forecast = self.location.get_clearsky(forecast_times, model='ineichen')['ghi']
+        cs_forecast = self.location.get_clearsky(forecast_times, model="ineichen")["ghi"]
 
         # Compute persistence factor
         if cs_current > 0:
@@ -81,7 +83,9 @@ class Model(BaseModel):
         else:
             k = torch.zeros_like(y_hat)
 
-        cs_forecast_tensor = torch.tensor(cs_forecast.values, dtype=y_hat.dtype, device=y_hat.device)
+        cs_forecast_tensor = torch.tensor(
+            cs_forecast.values, dtype=y_hat.dtype, device=y_hat.device
+        )
         forecast = k.unsqueeze(1) * cs_forecast_tensor.unsqueeze(0)
 
         return forecast


### PR DESCRIPTION
# Pull Request

## Description

This PR implements a new **Smart Persistence** baseline for PV forecasting. Unlike the naive persistence model that simply repeats the last GSP yield, Smart Persistence scales the yield using the ratio of forecasted clear‐sky irradiance to current clear‐sky irradiance:

Key changes:
- New model class (`smart_persistence`) using PVLIB’s Ineichen model.
- Requires a `"time"` key (list of datetime objects) in input data.
- Updated documentation, example usage, and tests.

This addresses issue #159.

## How Has This Been Tested?

- **Unit Testing:** New tests validate that short-horizon forecasts match current values and scale correctly.
- **Sanity Checks:** Forecast outputs have been plotted against expected clear‐sky curves.
- **Integration Testing:** Sample batch data (with `"gsp"` and `"time"`) confirms improved behavior over naive persistence.

## Checklist:

- [x] My code follows [[OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings 