### PR TITLE
Updated renewable attribute to 'pv_uk' for config.yaml

### DIFF
--- a/configs.example/config.yaml
+++ b/configs.example/config.yaml
@@ -12,7 +12,7 @@ defaults:
   - hparams_search: null
   - hydra: default.yaml
 
-renewable: "pv"
+renewable: "pv_uk"
 
 # enable color logging
 #  - override hydra/hydra_logging: colorlog


### PR DESCRIPTION
### Summary  
This PR updates `renewable` variable to 'pk_uk" in config.yaml, aligning with changes made in `save_samples.py`, which now only accepts `"pv_uk"` or `"site"`.

### Changes Made  
Updated renewable attribute to 'pv_uk' for config.yaml

### Issue Reference  
Fixes #345  

### Additional Notes  
Let me know if any further changes are required.  
