### PR TITLE
Add error distribution metrics

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -1,4 +1,5 @@
 """Base model for all PVNet submodels"""
+
 import json
 import logging
 import os
@@ -726,10 +727,18 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
                 # log error distribution metrics
                 wandb.log(
                     {
-                        "2nd_percentile_median_forecast_error": validation_results_df["error"].quantile(0.02),
-                        "5th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.05),
-                        "95th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.95),
-                        "98th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.98),
+                        "2nd_percentile_median_forecast_error": validation_results_df[
+                            "error"
+                        ].quantile(0.02),
+                        "5th_percentile_median_forecast_error": validation_results_df[
+                            "error"
+                        ].quantile(0.05),
+                        "95th_percentile_median_forecast_error": validation_results_df[
+                            "error"
+                        ].quantile(0.95),
+                        "98th_percentile_median_forecast_error": validation_results_df[
+                            "error"
+                        ].quantile(0.98),
                         "95th_percentile_median_forecast_absolute_error": abs(
                             validation_results_df["error"]
                         ).quantile(0.95),

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -718,19 +718,26 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         try:
             # join together validation results, and save to wandb
             validation_results_df = pd.concat(self.validation_epoch_results)
-            validation_results_df["error"] = validation_results_df["y"] - validation_results_df["y_quantile_0.5"]
+            validation_results_df["error"] = (
+                validation_results_df["y"] - validation_results_df["y_quantile_0.5"]
+            )
 
             if isinstance(self.logger, pl.loggers.WandbLogger):
-
-                # log error distribution metrics 
-                wandb.log({
-                    "95th_percentile_error": validation_results_df["error"].quantile(0.95),
-                    "5th_percentile_error": validation_results_df["error"].quantile(0.05),
-                    "98th_percentile_error": validation_results_df["error"].quantile(0.98),
-                    "2nd_percentile_error": validation_results_df["error"].quantile(0.02),
-                    "95th_percentile_absolute_error": abs(validation_results_df["error"]).quantile(0.95),
-                    "98th_percentile_absolute_error": abs(validation_results_df["error"]).quantile(0.98)
-                })
+                # log error distribution metrics
+                wandb.log(
+                    {
+                        "95th_percentile_error": validation_results_df["error"].quantile(0.95),
+                        "5th_percentile_error": validation_results_df["error"].quantile(0.05),
+                        "98th_percentile_error": validation_results_df["error"].quantile(0.98),
+                        "2nd_percentile_error": validation_results_df["error"].quantile(0.02),
+                        "95th_percentile_absolute_error": abs(
+                            validation_results_df["error"]
+                        ).quantile(0.95),
+                        "98th_percentile_absolute_error": abs(
+                            validation_results_df["error"]
+                        ).quantile(0.98),
+                    }
+                )
 
             with tempfile.TemporaryDirectory() as tempdir:
                 filename = os.path.join(tempdir, f"validation_results_{self.current_epoch}.csv")

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -726,14 +726,14 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
                 # log error distribution metrics
                 wandb.log(
                     {
-                        "95th_percentile_error": validation_results_df["error"].quantile(0.95),
-                        "5th_percentile_error": validation_results_df["error"].quantile(0.05),
-                        "98th_percentile_error": validation_results_df["error"].quantile(0.98),
-                        "2nd_percentile_error": validation_results_df["error"].quantile(0.02),
-                        "95th_percentile_absolute_error": abs(
+                        "95th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.95),
+                        "5th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.05),
+                        "98th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.98),
+                        "2nd_percentile_median_forecast_error": validation_results_df["error"].quantile(0.02),
+                        "95th_percentile_median_forecast_absolute_error": abs(
                             validation_results_df["error"]
                         ).quantile(0.95),
-                        "98th_percentile_absolute_error": abs(
+                        "98th_percentile_median_forecast_absolute_error": abs(
                             validation_results_df["error"]
                         ).quantile(0.98),
                     }

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -726,10 +726,10 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
                 # log error distribution metrics
                 wandb.log(
                     {
-                        "95th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.95),
-                        "5th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.05),
-                        "98th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.98),
                         "2nd_percentile_median_forecast_error": validation_results_df["error"].quantile(0.02),
+                        "5th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.05),
+                        "95th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.95),
+                        "98th_percentile_median_forecast_error": validation_results_df["error"].quantile(0.98),
                         "95th_percentile_median_forecast_absolute_error": abs(
                             validation_results_df["error"]
                         ).quantile(0.95),

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -718,6 +718,20 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         try:
             # join together validation results, and save to wandb
             validation_results_df = pd.concat(self.validation_epoch_results)
+            validation_results_df["error"] = validation_results_df["y"] - validation_results_df["y_quantile_0.5"]
+
+            if isinstance(self.logger, pl.loggers.WandbLogger):
+
+                # log error distribution metrics 
+                wandb.log({
+                    "95th_percentile_error": validation_results_df["error"].quantile(0.95),
+                    "5th_percentile_error": validation_results_df["error"].quantile(0.05),
+                    "98th_percentile_error": validation_results_df["error"].quantile(0.98),
+                    "2nd_percentile_error": validation_results_df["error"].quantile(0.02),
+                    "95th_percentile_absolute_error": abs(validation_results_df["error"]).quantile(0.95),
+                    "98th_percentile_absolute_error": abs(validation_results_df["error"]).quantile(0.98)
+                })
+
             with tempfile.TemporaryDirectory() as tempdir:
                 filename = os.path.join(tempdir, f"validation_results_{self.current_epoch}.csv")
                 validation_results_df.to_csv(filename, index=False)


### PR DESCRIPTION
# Pull Request

## Description

Adding error distribution metrics which will be tracked for the validation set and saved to W&B at each epoch end, implemented a simple version which is distribution of error and absolute error over all forecast steps 

I've had a go at deciding which metrics would be useful but please feel free to suggest changes or additions to them, thanks

Fixes #336 

