### PR TITLE
Enhance HF Hub Download Stability with Retry Mechanism

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -189,7 +189,10 @@ def download_hf_hub_with_retries(
             )
         except Exception as e:
             logging.warning(
-                f"Attempt {attempt}/{max_retries} failed to download {filename}. Retrying in {wait_time} seconds..."
+                (
+                    f"Attempt {attempt}/{max_retries} failed to download {filename}. "
+                    f"Retrying in {wait_time} seconds..."
+                )
             )
             if attempt == max_retries:
                 raise Exception(

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -153,7 +153,7 @@ def download_hf_hub_with_retries(
     token,
     local_files_only,
     max_retries=5,
-    wait_time=60,
+    wait_time=10,
 ):
     """
     Tries to download a file from HuggingFace up to max_retries times.
@@ -188,16 +188,16 @@ def download_hf_hub_with_retries(
                 local_files_only=local_files_only,
             )
         except Exception as e:
+            if attempt == max_retries:
+                raise Exception(
+                    f"Failed to download {filename} from {repo_id} after {max_retries} attempts."
+                ) from e
             logging.warning(
                 (
                     f"Attempt {attempt}/{max_retries} failed to download {filename}. "
                     f"Retrying in {wait_time} seconds..."
                 )
             )
-            if attempt == max_retries:
-                raise Exception(
-                    f"Failed to download {filename} from {repo_id} after {max_retries} attempts."
-                ) from e
             time.sleep(wait_time)
 
 
@@ -246,7 +246,7 @@ class PVNetModelHubMixin(PyTorchModelHubMixin):
             # load config file
             config_file = download_hf_hub_with_retries(
                 repo_id=model_id,
-                filename=DATA_CONFIG_NAME,
+                filename=CONFIG_NAME,
                 revision=revision,
                 cache_dir=cache_dir,
                 force_download=force_download,

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -194,8 +194,8 @@ def download_hf_hub_with_retries(
                 ) from e
             logging.warning(
                 (
-                    f"Attempt {attempt}/{max_retries} failed to download {filename}. "
-                    f"Retrying in {wait_time} seconds..."
+                    f"Attempt {attempt}/{max_retries} failed to download {filename} "
+                    f"from {repo_id}. Retrying in {wait_time} seconds..."
                 )
             )
             time.sleep(wait_time)

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -142,8 +142,19 @@ def minimize_data_config(input_path, output_path, model):
         yaml.dump(config, outfile, default_flow_style=False)
 
 
-
-def download_hf_hub_with_retries(repo_id, filename, revision, cache_dir, force_download, proxies, resume_download, token, local_files_only, max_retries=5, wait_time=60):
+def download_hf_hub_with_retries(
+    repo_id,
+    filename,
+    revision,
+    cache_dir,
+    force_download,
+    proxies,
+    resume_download,
+    token,
+    local_files_only,
+    max_retries=5,
+    wait_time=60,
+):
     """
     Tries to download a file from HuggingFace up to max_retries times.
 
@@ -159,7 +170,7 @@ def download_hf_hub_with_retries(repo_id, filename, revision, cache_dir, force_d
         local_files_only (bool): Use local files only
         max_retries (int): Maximum number of retry attempts
         wait_time (int): Wait time (in seconds) before retrying
-    
+
     Returns:
         str: The local file path of the downloaded file
     """
@@ -177,9 +188,13 @@ def download_hf_hub_with_retries(repo_id, filename, revision, cache_dir, force_d
                 local_files_only=local_files_only,
             )
         except Exception as e:
-            logging.warning(f"Attempt {attempt}/{max_retries} failed to download {filename}. Retrying in {wait_time} seconds...")
+            logging.warning(
+                f"Attempt {attempt}/{max_retries} failed to download {filename}. Retrying in {wait_time} seconds..."
+            )
             if attempt == max_retries:
-                raise Exception(f"Failed to download {filename} from {repo_id} after {max_retries} attempts.") from e
+                raise Exception(
+                    f"Failed to download {filename} from {repo_id} after {max_retries} attempts."
+                ) from e
             time.sleep(wait_time)
 
 
@@ -224,7 +239,7 @@ class PVNetModelHubMixin(PyTorchModelHubMixin):
                 max_retries=5,
                 wait_time=60,
             )
-            
+
             # load config file
             config_file = download_hf_hub_with_retries(
                 repo_id=model_id,
@@ -239,7 +254,6 @@ class PVNetModelHubMixin(PyTorchModelHubMixin):
                 max_retries=5,
                 wait_time=60,
             )
-
 
         with open(config_file, "r", encoding="utf-8") as f:
             config = json.load(f)


### PR DESCRIPTION
# Pull Request

## Description

This PR includes a reusable helper function that implements a retry mechanism when downloading models from HuggingFace. This function retries the download a specified number of times before failing.

Fixes #354 

## How Has This Been Tested?

- I have executed the download retry function to simulate network failures and confirmed that it retries the expected number of times before raising an error.
- All changes have been verified by running the full test suite.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
