### PR TITLE
add sample to class in save samples

### DIFF
--- a/scripts/save_samples.py
+++ b/scripts/save_samples.py
@@ -80,10 +80,10 @@ class SaveFuncFactory:
         save_path = f"{self.save_dir}/{sample_num:08}"
 
         if self.renewable == "pv_uk":
-            sample_class = UKRegionalSample()
+            sample_class = UKRegionalSample(sample)
             filename = f"{save_path}.pt"
         elif self.renewable == "site":
-            sample_class = SiteSample()
+            sample_class = SiteSample(sample)
             filename = f"{save_path}.nc"
         else:
             raise ValueError(f"Unknown renewable: {self.renewable}")


### PR DESCRIPTION
# Pull Request

## Description

The data contained in sample is required when creating the class object for UKRegionalSample and SiteSample. This is a small PR to add sample back into the class functions.


## How Has This Been Tested?

This fixes the issues of failing to train due to data not being passed into the class object. I have run training now locally and performs as expected 
- [X] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
