### PR TITLE
Update example config with correct DataModule path

### DIFF
--- a/configs.example/datamodule/configuration/example_configuration.yaml
+++ b/configs.example/datamodule/configuration/example_configuration.yaml
@@ -281,3 +281,8 @@ input_data:
       WV_073:
         mean: 0.62479186
         std: 0.12924142
+
+  solar_position:
+    interval_start_minutes: -60
+    interval_end_minutes: 480
+    time_resolution_minutes: 5

--- a/configs.example/datamodule/configuration/example_configuration.yaml
+++ b/configs.example/datamodule/configuration/example_configuration.yaml
@@ -285,4 +285,4 @@ input_data:
   solar_position:
     interval_start_minutes: -60
     interval_end_minutes: 480
-    time_resolution_minutes: 5
+    time_resolution_minutes: 30

--- a/configs.example/datamodule/premade_batches.yaml
+++ b/configs.example/datamodule/premade_batches.yaml
@@ -1,4 +1,4 @@
-_target_: pvnet.data.datamodule.DataModule
+_target_: pvnet.data.DataModule
 configuration: null
 
 # The sample_dir is the location batches were saved to using the save_batches.py script

--- a/configs.example/datamodule/streamed_batches.yaml
+++ b/configs.example/datamodule/streamed_batches.yaml
@@ -1,4 +1,4 @@
-_target_: pvnet.data.datamodule.DataModule
+_target_: pvnet.data.DataModule
 # Path to the data configuration yaml file. You can find examples in the configuration subdirectory
 # in configs.example/datamodule/configuration
 # Use the full local path such as: /FULL/PATH/PVNet/configs/datamodule/configuration/gcp_configuration.yaml"


### PR DESCRIPTION
# Pull Request

## Description

- DataModule(s) are now imported directly from pvnet/data/__init__.py and target pvnet.data.datamodule.DataModule is no longer valid
- Added sun position config to the example configuration

## How Has This Been Tested?

Ran run.py with updated premade_batches.yaml as datamodule

- [X] Yes
