### PR TITLE
use torch.load with weights_only=False in load_model.py

### DIFF
--- a/pvnet/load_model.py
+++ b/pvnet/load_model.py
@@ -34,9 +34,10 @@ def get_model_from_checkpoints(
                 raise ValueError(
                     f"Found {len(files)} checkpoints @ {path}/epoch*.ckpt. Expected one."
                 )
-            checkpoint = torch.load(files[0], map_location="cpu")
+            # TODO: Loading with weights_only=False is not recommended
+            checkpoint = torch.load(files[0], map_location="cpu", weights_only=False)
         else:
-            checkpoint = torch.load(f"{path}/last.ckpt", map_location="cpu")
+            checkpoint = torch.load(f"{path}/last.ckpt", map_location="cpu", weights_only=False)
 
         model.load_state_dict(state_dict=checkpoint["state_dict"])
 


### PR DESCRIPTION
# Pull Request

## Description

Added `weights_only=False` to `torch.load` in loading model from checkpoint, as was unable to push to HF without this. This is the same issue we encounter in [ocf_data_sampler/torch_datasets/sample/uk_regional.py](https://github.com/openclimatefix/ocf-data-sampler/blob/563e6370863c52466f72bf0747f3513654a4098a/ocf_data_sampler/torch_datasets/sample/uk_regional.py#L55-L56). This fix is not recommended due to the possibility of random code execution when unpickling. I think it's fairly unlikely for us to accidentally load something that's not the model, but still not the best practice, hence the todo
