### PR TITLE
Fix num_embeddings so max embedding num is allowed

### DIFF
--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -152,7 +152,7 @@ class Model(MultimodalBaseModel):
         self.use_id_embedding = location_id_mapping is not None
 
         if self.use_id_embedding:
-            num_embeddings = max(location_id_mapping.values())
+            num_embeddings = max(location_id_mapping.values()) + 1
 
         super().__init__(
             history_minutes=history_minutes,

--- a/pvnet/models/multimodal/unimodal_teacher.py
+++ b/pvnet/models/multimodal/unimodal_teacher.py
@@ -106,7 +106,7 @@ class Model(MultimodalBaseModel):
         self.use_id_embedding = location_id_mapping is not None
 
         if self.use_id_embedding:
-            num_embeddings = max(location_id_mapping.values())
+            num_embeddings = max(location_id_mapping.values()) + 1
 
         # This is set but modified later based on the teachers
         self.add_image_embedding_channel = False


### PR DESCRIPTION
# Pull Request

## Description

Previously `num_embeddings` to the maximum value in the `location_id_mapping` dict. The pytorch `nn.Embedding` layer is zero indexed, therefore to be able to use the embedding ID N the `num_embeddings` parameter must be set to N+1

