### PR TITLE
Default to not saving validation results csv

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -476,6 +476,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
         interval_minutes: int = 30,
         timestep_intervals_to_plot: Optional[list[int]] = None,
         forecast_minutes_ignore: Optional[int] = 0,
+        save_validation_results_csv: Optional[bool] = False,
     ):
         """Abtstract base class for PVNet submodels.
 
@@ -534,6 +535,7 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
 
         # save all validation results to array, so we can save these to weights n biases
         self.validation_epoch_results = []
+        self.save_validation_results_csv = save_validation_results_csv
 
     def transfer_batch_to_device(self, batch, device, dataloader_idx):
         """Method to move custom batches to a given device"""
@@ -869,17 +871,19 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
                         ).quantile(0.98),
                     }
                 )
+            # saving validation result csvs
+            if self.save_validation_results_csv:
+                with tempfile.TemporaryDirectory() as tempdir:
+                    filename = os.path.join(tempdir, f"validation_results_{self.current_epoch}.csv")
+                    validation_results_df.to_csv(filename, index=False)
 
-            with tempfile.TemporaryDirectory() as tempdir:
-                filename = os.path.join(tempdir, f"validation_results_{self.current_epoch}.csv")
-                validation_results_df.to_csv(filename, index=False)
-
-                # make and log wand artifact
-                validation_artifact = wandb.Artifact(
-                    f"validation_results_epoch_{self.current_epoch}", type="dataset"
-                )
-                validation_artifact.add_file(filename)
-                wandb.log_artifact(validation_artifact)
+                    # make and log wand artifact
+                    validation_artifact = wandb.Artifact(
+                        f"validation_results_epoch_{self.current_epoch}", type="dataset"
+                    )
+                    validation_artifact.add_file(filename)
+                    wandb.log_artifact(validation_artifact)
+                    
         except Exception as e:
             print("Failed to log validation results to wandb")
             print(e)

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -68,6 +68,7 @@ class Model(MultimodalBaseModel):
         timestep_intervals_to_plot: Optional[list[int]] = None,
         adapt_batches: Optional[bool] = False,
         forecast_minutes_ignore: Optional[int] = 0,
+        save_validation_results_csv: Optional[bool] = False,
     ):
         """Neural network which combines information from different sources.
 
@@ -127,6 +128,7 @@ class Model(MultimodalBaseModel):
                 data we need for a model run.
             forecast_minutes_ignore: Number of forecast minutes to ignore when calculating losses.
                 For example if set to 60, the model doesnt predict the first 60 minutes
+            save_validation_results_csv: whether to save full csv outputs from validation results. 
         """
 
         self.include_gsp_yield_history = include_gsp_yield_history
@@ -151,6 +153,7 @@ class Model(MultimodalBaseModel):
             interval_minutes=interval_minutes,
             timestep_intervals_to_plot=timestep_intervals_to_plot,
             forecast_minutes_ignore=forecast_minutes_ignore,
+            save_validation_results_csv=save_validation_results_csv
         )
 
         # Number of features expected by the output_network


### PR DESCRIPTION
# Pull Request

## Description

This change means that the default is not saving the validation inference outputs in csvs (as these can be quite large and take up lots of storage space on W&B), instead they can be saved by adding 
`save_validation_results_csv = True` to the model_config.yaml file, they will still save all epochs as there is not an easy way to only save the last/best one. 

## How Has This Been Tested?

Tested on some mock training runs
