### PR TITLE
save model configs to yaml format

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -261,7 +261,7 @@ class PVNetModelHubMixin(PyTorchModelHubMixin):
                 max_retries=5,
                 wait_time=10,
             )
-            
+
         with open(config_file, "r") as f:
             config = yaml.safe_load(f)
 
@@ -357,7 +357,7 @@ class PVNetModelHubMixin(PyTorchModelHubMixin):
         if isinstance(config, dict):
             with open(save_directory / CONFIG_NAME, "w") as f:
                 yaml.dump(config, f)
-        
+
         # Save cleaned configuration file
         if data_config is not None:
             new_data_config_path = save_directory / DATA_CONFIG_NAME

--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -1,6 +1,5 @@
 """Base model for all PVNet submodels"""
 import copy
-import json
 import logging
 import os
 import tempfile
@@ -262,9 +261,9 @@ class PVNetModelHubMixin(PyTorchModelHubMixin):
                 max_retries=5,
                 wait_time=10,
             )
-
-        with open(config_file, "r", encoding="utf-8") as f:
-            config = json.load(f)
+            
+        with open(config_file, "r") as f:
+            config = yaml.safe_load(f)
 
         model = hydra.utils.instantiate(config)
 
@@ -356,8 +355,9 @@ class PVNetModelHubMixin(PyTorchModelHubMixin):
 
         # saving model and data config
         if isinstance(config, dict):
-            (save_directory / CONFIG_NAME).write_text(json.dumps(config, indent=4))
-
+            with open(save_directory / CONFIG_NAME, "w") as f:
+                yaml.dump(config, f)
+        
         # Save cleaned configuration file
         if data_config is not None:
             new_data_config_path = save_directory / DATA_CONFIG_NAME

--- a/scripts/checkpoint_to_huggingface.py
+++ b/scripts/checkpoint_to_huggingface.py
@@ -54,7 +54,7 @@ def push_to_huggingface(
                 wandb_ids.append(None)
 
     model, model_config, data_config = get_model_from_checkpoints(checkpoint_dir_paths, val_best)
-
+    
     if not is_ensemble:
         wandb_ids = wandb_ids[0]
 

--- a/scripts/checkpoint_to_huggingface.py
+++ b/scripts/checkpoint_to_huggingface.py
@@ -54,7 +54,7 @@ def push_to_huggingface(
                 wandb_ids.append(None)
 
     model, model_config, data_config = get_model_from_checkpoints(checkpoint_dir_paths, val_best)
-    
+
     if not is_ensemble:
         wandb_ids = wandb_ids[0]
 


### PR DESCRIPTION
# Pull Request

## Description

Currently we are saving our model configs to json format (although we put them into a file called `.yaml`). This has worked fine until now. However, the new `location_id_mapping` introduced in #375 poses a problems for the json format. When saving to json it changes the integer keys of the `location_id_mapping` to strings. This breaks the model config so that the model will run after loading. 

This PR changes the saving so that we use the `yaml` library to save the model config
