### PR TITLE
Maintain config ordering on save

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -17,7 +17,7 @@ import torch.nn.functional as F
 import wandb
 import yaml
 from huggingface_hub import ModelCard, ModelCardData, PyTorchModelHubMixin
-from huggingface_hub.constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
+from huggingface_hub.constants import PYTORCH_WEIGHTS_NAME
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import HfApi
 from ocf_data_sampler.torch_datasets.sample.base import copy_batch_to_device
@@ -32,6 +32,7 @@ from pvnet.optimizers import AbstractOptimizer
 from pvnet.utils import plot_batch_forecasts
 
 DATA_CONFIG_NAME = "data_config.yaml"
+CONFIG_NAME = "config.yaml"
 
 
 logger = logging.getLogger(__name__)
@@ -356,7 +357,7 @@ class PVNetModelHubMixin(PyTorchModelHubMixin):
         # saving model and data config
         if isinstance(config, dict):
             with open(save_directory / CONFIG_NAME, "w") as f:
-                yaml.dump(config, f)
+                yaml.dump(config, f, sort_keys=False, default_flow_style=False)
 
         # Save cleaned configuration file
         if data_config is not None:


### PR DESCRIPTION
# Pull Request

## Description

A bug was introduced in #382 when we changed from saving the model config in yaml format instead of json. When saving to yaml, by default the dictionary keys are reordered to alphabetical order. The order of the `nwp_encoder_dict` dictates the order in which the nwp features are stacked before the final dense layers of the PVNet network. In one of my recent runs, I had `"ukv"` and `"ecmwf"` NWP encoders. This means when reloading the model from the saved yaml, it was stacking the NWP features in the reverse order then when training.

This PR stops the confoig being reordered on save

Also renames the save file to reflect the move to yaml instead of json.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
