### PR TITLE
add default location id mapping back in

### DIFF
--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -158,7 +158,7 @@ class Model(BaseModel):
             # for models trained with this default embedding
             location_id_mapping = {i: i for i in range(318)}
 
-        self.use_id_embedding = location_id_mapping is not None
+        self.use_id_embedding = (location_id_mapping is not None) and (self.embedding_dim is not None)
 
         if self.use_id_embedding:
             num_embeddings = max(location_id_mapping.values()) + 1

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -1,5 +1,6 @@
 """The default composite model architecture for PVNet"""
 
+import logging
 from collections import OrderedDict
 from typing import Any, Optional
 
@@ -14,6 +15,8 @@ from pvnet.models.multimodal.encoders.basic_blocks import AbstractNWPSatelliteEn
 from pvnet.models.multimodal.linear_networks.basic_blocks import AbstractLinearNetwork
 from pvnet.models.multimodal.site_encoders.basic_blocks import AbstractSitesEncoder
 from pvnet.optimizers import AbstractOptimizer
+
+logger = logging.getLogger(__name__)
 
 
 class Model(BaseModel):
@@ -149,10 +152,12 @@ class Model(BaseModel):
         self.adapt_batches = adapt_batches
 
         if location_id_mapping is None and add_image_embedding_channel:
-            raise ValueError(
-                "If `add_image_embedding_channel` is set to True, `location_id_mapping` must be "
-                "provided."
-            )
+            logger.warning("Multimodel: add_image_embedding_channel` is set to True "
+                           "but no `location_id_mapping` provided, we'll set a default")
+
+            # Note 318 is the 2024 GSP count, so this is a temporary fix
+            # for models trained with this default embedding
+            location_id_mapping = {i: i for i in range(318)}
 
         self.use_id_embedding = location_id_mapping is not None
 

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -158,7 +158,8 @@ class Model(BaseModel):
             # for models trained with this default embedding
             location_id_mapping = {i: i for i in range(318)}
 
-        self.use_id_embedding = (location_id_mapping is not None) and (self.embedding_dim is not None)
+        self.use_id_embedding \
+            = (location_id_mapping is not None) and (self.embedding_dim is not None)
 
         if self.use_id_embedding:
             num_embeddings = max(location_id_mapping.values()) + 1

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -152,7 +152,8 @@ class Model(BaseModel):
         self.adapt_batches = adapt_batches
 
         if location_id_mapping is None:
-            logger.warning("location_id_mapping` is not provided, defaulting to outdated GSP mapping (1 to 318)")
+            logger.warning("location_id_mapping` is not provided, "
+                           "defaulting to outdated GSP mapping (0 to 317)")
 
             # Note 318 is the 2024 UK GSP count, so this is a temporary fix
             # for models trained with this default embedding

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -152,7 +152,7 @@ class Model(BaseModel):
         self.adapt_batches = adapt_batches
 
         if location_id_mapping is None:
-            logger.warning("location_id_mapping` is not provided, we'll set a default")
+            logger.warning("location_id_mapping` is not provided, defaulting to outdated GSP mapping (1 to 318)")
 
             # Note 318 is the 2024 UK GSP count, so this is a temporary fix
             # for models trained with this default embedding

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -151,9 +151,8 @@ class Model(BaseModel):
         self.min_sat_delay_minutes = min_sat_delay_minutes
         self.adapt_batches = adapt_batches
 
-        if location_id_mapping is None and add_image_embedding_channel:
-            logger.warning("Multimodel: add_image_embedding_channel` is set to True "
-                           "but no `location_id_mapping` provided, we'll set a default")
+        if location_id_mapping is None:
+            logger.warning("location_id_mapping` is not provided, we'll set a default")
 
             # Note 318 is the 2024 UK GSP count, so this is a temporary fix
             # for models trained with this default embedding

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -155,7 +155,7 @@ class Model(BaseModel):
             logger.warning("Multimodel: add_image_embedding_channel` is set to True "
                            "but no `location_id_mapping` provided, we'll set a default")
 
-            # Note 318 is the 2024 GSP count, so this is a temporary fix
+            # Note 318 is the 2024 UK GSP count, so this is a temporary fix
             # for models trained with this default embedding
             location_id_mapping = {i: i for i in range(318)}
 

--- a/pvnet/models/multimodal/multimodal.py
+++ b/pvnet/models/multimodal/multimodal.py
@@ -159,8 +159,9 @@ class Model(BaseModel):
             # for models trained with this default embedding
             location_id_mapping = {i: i for i in range(318)}
 
-        self.use_id_embedding \
-            = (location_id_mapping is not None) and (self.embedding_dim is not None)
+        # in the future location_id_mapping could be None,
+        # and in this case use_id_embedding should be False
+        self.use_id_embedding = self.embedding_dim is not None
 
         if self.use_id_embedding:
             num_embeddings = max(location_id_mapping.values()) + 1


### PR DESCRIPTION
# Pull Request

## Description

Following on from https://github.com/openclimatefix/PVNet/pull/375/files, we've added back a default location mapping 
This helps with PVnet models trained with <4.1.8

## How Has This Been Tested?

- [ ] CI tests

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
