### PR TITLE
Adapt site batch 

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -563,6 +563,24 @@ class BaseModel(pl.LightningModule, PVNetModelHubMixin):
             new_batch["gsp"] = new_batch["gsp"][:, :gsp_len]
             new_batch["gsp_time_utc"] = new_batch["gsp_time_utc"][:, :gsp_len]
 
+        if "site" in new_batch.keys():
+            # Slice off the end of the site data
+            site_len = self.forecast_len + self.history_len + 1
+            new_batch["site"] = new_batch["site"][:, :site_len]
+
+            # Slice all site related datetime coordinates and features
+            site_time_keys = [
+                "site_time_utc",
+                "site_date_sin",
+                "site_date_cos", 
+                "site_time_sin",
+                "site_time_cos",
+            ]
+            
+            for key in site_time_keys:
+                if key in new_batch.keys():
+                    new_batch[key] = new_batch[key][:, :site_len]
+
         if self.include_sat:
             # Slice off the end of the satellite data and spatially crop
             # Shape: batch_size, seq_length, channel, height, width

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dynamic = ["version", "readme"]
 license={file="LICENCE"}
 
 dependencies = [
-    "ocf-data-sampler>=0.2.10",
+    "ocf-data-sampler>=0.2.32",
     "numpy",
     "pandas",
     "matplotlib",


### PR DESCRIPTION
# Pull Request

## Description
This pull request introduces a modification to the `_adapt_batch` method in `pvnet/models/base_model.py` to handle slicing of site-related data when it is included in the batch. This ensures consistency in the length of site data and its associated features.]

ocf-data-sampler version has also been upgraded.

Addressing issue #403 

### Changes related to handling site data:
* Added logic to slice the `site` data to match the combined forecast and history lengths plus one (`site_len`).
* Introduced a loop to slice all site-related datetime coordinates and features (`site_time_utc`, `site_date_sin`, `site_date_cos`, `site_time_sin`, `site_time_cos`) to the same length as `site_len`, ensuring alignment across all site-related data.

## How Has This Been Tested?

Locally to ensure correct slicing. Trained a new model using this method.

- [X] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [X] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
