### PR TITLE
Add epoch-consistent shuffling to validation streamed sample dataloader

### DIFF
--- a/pvnet/data/base_datamodule.py
+++ b/pvnet/data/base_datamodule.py
@@ -136,7 +136,7 @@ class BaseStreamedDataModule(LightningDataModule):
     def setup(self, stage: str | None = None):
         """Called once to prepare the datasets."""
 
-        # This logic runs only once at the start of training, therefore the val dataset is only 
+        # This logic runs only once at the start of training, therefore the val dataset is only
         # shuffled once
         if stage == "fit":
             # Prepare the train dataset

--- a/pvnet/data/base_datamodule.py
+++ b/pvnet/data/base_datamodule.py
@@ -136,8 +136,8 @@ class BaseStreamedDataModule(LightningDataModule):
     def setup(self, stage: str | None = None):
         """Called once to prepare the datasets."""
 
-        # This logic runs only once at the start of training making it robust.
-        # Therefore the val dataset is only shuffled once
+        # This logic runs only once at the start of training, therefore the val dataset is only 
+        # shuffled once
         if stage == "fit":
             # Prepare the train dataset
             self.train_dataset = self._get_streamed_samples_dataset(*self.train_period)


### PR DESCRIPTION
# Pull Request

## Description

If we are streaming samples during training (which we hope to do using xarray-tensorstore openclimatefix/ocf-data-sampler#254) then our current implementation means that the validation samples are not shuffled. 

We often only use a subset of the validation samples since we set the `limit_val_batches` parameter in the lightning `Trainer` object. Since we aren't iterating through the entire validation set, this means we only from the start of the validation period rather than sampled throughout the period.

This PR adds a shuffle to the validation dataset, so that the set of validation samples used during training is sampled from the whole time period. The shuffle is done such that the exact same random selection of validation samples will be used on each epoch.


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
