### PR TITLE
Remove unused functionality

### DIFF
--- a/configs.example/config.yaml
+++ b/configs.example/config.yaml
@@ -26,20 +26,7 @@ work_dir: ${hydra:runtime.cwd}
 
 model_name: "default"
 
-# use `python run.py debug=true` for easy debugging!
-# this will run 1 train, val and test loop with only 1 batch
-# equivalent to running `python run.py trainer.fast_dev_run=true`
-# (this is placed here just for easier access from command line)
-debug: False
-
 # pretty print config at the start of the run using Rich library
 print_config: True
-
-# disable python warnings if they annoy you
-ignore_warnings: True
-
-# check performance on test set, using the best model achieved during training
-# lightning chooses best model based on metric specified in checkpoint callback
-test_after_training: False
 
 seed: 2727831

--- a/pvnet/utils.py
+++ b/pvnet/utils.py
@@ -1,6 +1,5 @@
 """Utils"""
 import logging
-import warnings
 from collections.abc import Sequence
 from typing import Optional
 
@@ -98,8 +97,6 @@ def extras(config: DictConfig) -> None:
     """A couple of optional utilities.
 
     Controlled by main config file:
-    - disabling warnings
-    - easier access to debug mode
     - forcing debug friendly configuration
 
     Modifies DictConfig in place.
@@ -112,16 +109,6 @@ def extras(config: DictConfig) -> None:
 
     # enable adding new keys to config
     OmegaConf.set_struct(config, False)
-
-    # disable python warnings if <config.ignore_warnings=True>
-    if config.get("ignore_warnings"):
-        log.info("Disabling python warnings! <config.ignore_warnings=True>")
-        warnings.filterwarnings("ignore")
-
-    # set <config.trainer.fast_dev_run=True> if <config.debug=True>
-    if config.get("debug"):
-        log.info("Running in debug mode! <config.debug=True>")
-        config.trainer.fast_dev_run = True
 
     # force debugger friendly configuration if <config.trainer.fast_dev_run=True>
     if config.trainer.get("fast_dev_run"):
@@ -174,9 +161,6 @@ def print_config(
         branch.add(rich.syntax.Syntax(branch_content, "yaml"))
 
     rich.print(tree)
-
-    with open("config_tree.txt", "w") as fp:
-        rich.print(tree, file=fp)
 
 
 def empty(*args, **kwargs):
@@ -237,9 +221,6 @@ def plot_batch_forecasts(
     timesteps_to_plot: Optional[list[int]] = None,
 ):
     """Plot a batch of data and the forecast from that batch"""
-
-    def _get_numpy(key):
-        return batch[key].cpu().numpy().squeeze()
 
     y_key = key_to_plot
     y_id_key = f"{key_to_plot}_id"

--- a/scripts/backtest_sites.py
+++ b/scripts/backtest_sites.py
@@ -5,7 +5,8 @@ Use:
 
 - This script uses hydra to construct the config, just like in `run.py`. So you need to make sure
   that the data config is set up appropriate for the model being run in this script
-- The following variables are hard coded near the top of the script and should be changed prior to use:
+- The following variables are hard coded near the top of the script and should be changed prior to
+  use:
   The PVNet model checkpoint (either local or HuggingFace repo details);
   the time range over which predictions are made;
   the output directory where the results are stored; time parameters (window and frequency)


### PR DESCRIPTION
# Pull Request

## Description

This removes some pieces which aren't being used

- Remove debug option which I don't believe anyone is using (and can be replicated anyway with setting `trainer.fast_dev_run`)
- Remove unused internal function `_get_numpy()` - this must have been left orphaned in a previous PR
- Remove `ignore_warnings` option. Let's fix them, or exclude these warnings one-by-one
- The `test_after_training` option was already removed. Remove it from example config
- Remove saving the config to `"config_tree.txt"`. We print this at the start of our training log anyway
