### PR TITLE
Batch validation function addition

### DIFF
--- a/pvnet/utils.py
+++ b/pvnet/utils.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pylab
 import rich.syntax
 import rich.tree
+import torch
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.utilities import rank_zero_only
 from omegaconf import DictConfig, OmegaConf
@@ -232,3 +233,112 @@ def plot_batch_forecasts(
     plt.tight_layout()
 
     return fig
+
+
+def _check_shape_and_raise(
+    data_key: str,
+    tensor: torch.Tensor,
+    expected_shape: tuple,
+    dim_names: list[str]
+) -> None:
+    """
+    Checks if actual shape matches expected shape - raises a detailed error on mismatch.
+
+    Args:
+        data_key: A string identifying the data being checked (e.g., "NWP.ukv").
+        tensor: The tensor object whose shape is to be validated.
+        expected_shape: The expected shape of the tensor.
+        dim_names: A list of names for each dimension for more descriptive errors.
+
+    Raises:
+        ValueError: If the shapes do not match.
+    """
+    actual_shape = tuple(tensor.shape)
+    if actual_shape == expected_shape:
+        return
+
+    if len(actual_shape) != len(expected_shape):
+        raise ValueError(
+            f"Shape mismatch for '{data_key}': Incorrect number of dimensions. "
+            f"Expected {len(expected_shape)} dims with shape {expected_shape}, "
+            f"but got {len(actual_shape)} dims with shape {actual_shape}."
+        )
+
+    for i, (actual, expected) in enumerate(zip(actual_shape, expected_shape)):
+        if actual != expected:
+            dim_name = dim_names[i] if i < len(dim_names) else f"dim_{i}"
+            raise ValueError(
+                f"Shape mismatch for '{data_key}' in dimension '{dim_name}'. "
+                f"Expected size {expected}, but got {actual}. "
+                f"Full Expected Shape: {expected_shape}, Full Actual Shape: {actual_shape}."
+            )
+
+
+def validate_batch_against_config(
+    batch: dict,
+    model_config: DictConfig,
+    sat_interval_minutes: int = 5,
+    gsp_interval_minutes: int = 30,
+) -> None:
+    """
+    Validates the shapes of tensors in a batch against the model's configuration.
+
+    Context-aware error messages when a batch's tensor shape does not match the 
+    shape expected by the model configuration.
+
+    Args:
+        batch: A dictionary of tensors from the dataloader.
+        model_config: The model's configuration object (e.g., config.model).
+        sat_interval_minutes: The time resolution of the satellite data in minutes.
+        gsp_interval_minutes: The time resolution of the GSP data in minutes.
+
+    Raises:
+        ValueError: If a tensor shape mismatches the expected shape derived from the config.
+    """
+    log = get_logger(__name__)
+    log.info("Performing batch shape validation against model config.")
+    dim_names = ["batch", "time", "channels", "height", "width", "sites"]
+
+    if "nwp" in batch and "nwp_encoders_dict" in model_config:
+        for source, nwp_tensor in batch["nwp"].items():
+            if source not in model_config.nwp_encoders_dict:
+                continue
+
+            cfg = model_config.nwp_encoders_dict[source]
+            hist_mins = model_config.nwp_history_minutes[source]
+            fcst_mins = model_config.nwp_forecast_minutes[source]
+            interval = model_config.nwp_interval_minutes[source]
+            exp_time = (hist_mins + fcst_mins) // interval + 1
+            
+            expected_shape = (
+                nwp_tensor.shape[0],
+                exp_time,
+                cfg.in_channels,
+                cfg.image_size_pixels,
+                cfg.image_size_pixels,
+            )
+            _check_shape_and_raise(f"NWP.{source}",
+            nwp_tensor,
+            expected_shape,
+            dim_names)
+
+    if "sat" in batch and "sat_encoder" in model_config:
+        sat_tensor = batch["sat"]
+        cfg = model_config.sat_encoder
+        exp_time = model_config.sat_history_minutes // sat_interval_minutes + 1
+        expected_shape = (
+            sat_tensor.shape[0],
+            exp_time,
+            cfg.in_channels,
+            cfg.image_size_pixels,
+            cfg.image_size_pixels,
+        )
+        _check_shape_and_raise("Satellite", sat_tensor, expected_shape, dim_names)
+
+    if "gsp" in batch:
+        gsp_tensor = batch["gsp"]
+        exp_forecast_steps = model_config.forecast_minutes // gsp_interval_minutes
+        expected_shape = (gsp_tensor.shape[0], exp_forecast_steps)
+        _check_shape_and_raise("GSP Target", gsp_tensor, expected_shape, dim_names)
+
+    log.info("Batch shape validation success.")

--- a/tests/models/multimodal/test_validation.py
+++ b/tests/models/multimodal/test_validation.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from pvnet.utils import validate_batch_against_config
+from pvnet.models.multimodal.multimodal import Model
+
+
+def test_validate_batch_against_config(sample_batch: dict, multimodal_model: Model):
+    
+    if "satellite_actual" in sample_batch:
+        sample_batch["sat"] = sample_batch.pop("satellite_actual")
+    
+    # Assert valid data passes the check without error
+    validate_batch_against_config(sample_batch, multimodal_model.hparams)
+
+    # Intentionally corrupt data and assert that error is raised
+    invalid_batch = sample_batch.copy()    
+    invalid_batch["sat"] = sample_batch["sat"][:, :-1]
+
+    with pytest.raises(ValueError, match="Shape mismatch for 'Satellite' in dimension 'time'"):
+        validate_batch_against_config(invalid_batch, multimodal_model.hparams)


### PR DESCRIPTION
Function entitled validate_batch_against_config added to pvnet/utils.py - to compare the shapes in a batch against the model config directly.

Triggers as a one time check on the initial training batch - implemented by on_train_batch_start in BaseModel class.

Should fundamentally now provide solid context regarding the exact data source and specific dimension that is incorrect.