### PR TITLE
Add seed to val shuffle for reproducibility

### DIFF
--- a/configs.example/config.yaml
+++ b/configs.example/config.yaml
@@ -26,7 +26,4 @@ work_dir: ${hydra:runtime.cwd}
 
 model_name: "default"
 
-# pretty print config at the start of the run using Rich library
-print_config: True
-
 seed: 2727831

--- a/configs.example/datamodule/streamed_samples.yaml
+++ b/configs.example/datamodule/streamed_samples.yaml
@@ -14,3 +14,5 @@ train_period:
 val_period:
   - "2022-05-08"
   - "2023-05-08"
+
+seed: "${seed}"


### PR DESCRIPTION
# Pull Request

## Description

With the streamed sample datamodule, we previously did not control the seeding in it. When training two different models which had the same global seed and same data config we could end up with completely different val samples. This fixes the issue and will make it easier to compare between models.

Additionally remove unused print_config param in example config

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
