### PR TITLE
Update site history

### DIFF
--- a/pvnet/models/late_fusion/late_fusion.py
+++ b/pvnet/models/late_fusion/late_fusion.py
@@ -221,7 +221,7 @@ class LateFusionModel(BaseModel):
             assert pv_history_minutes is not None
 
             self.pv_encoder = pv_encoder(
-                sequence_length=pv_history_minutes // pv_interval_minutes + 1,
+                sequence_length=pv_history_minutes // pv_interval_minutes,
                 target_key_to_use=self._target_key,
                 input_key_to_use="site",
             )
@@ -261,7 +261,7 @@ class LateFusionModel(BaseModel):
 
         if include_site_yield_history:
             # Update num features
-            fusion_input_features += self.history_len + 1
+            fusion_input_features += self.history_len
 
         self.output_network = output_network(
             in_features=fusion_input_features,

--- a/pvnet/models/late_fusion/late_fusion.py
+++ b/pvnet/models/late_fusion/late_fusion.py
@@ -313,7 +313,7 @@ class LateFusionModel(BaseModel):
         # *********************** Site Data *************************************
         # Add site-level yield history
         if self.include_site_yield_history:
-            site_history = x["site"][:, : self.history_len + 1].float()
+            site_history = x["site"][:, : self.history_len].float()
             site_history = site_history.reshape(site_history.shape[0], -1)
             modes["site"] = site_history
 
@@ -325,7 +325,7 @@ class LateFusionModel(BaseModel):
                 # Target is PV, so only take the history
                 # Copy batch
                 x_tmp = x.copy()
-                x_tmp["site"] = x_tmp["site"][:, : self.history_len + 1]
+                x_tmp["site"] = x_tmp["site"][:, : self.history_len]
                 modes["site"] = self.pv_encoder(x_tmp)
 
         # *********************** GSP Data ************************************

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,7 +278,7 @@ def uk_batch(uk_streamed_datamodule) -> TensorBatch:
 @pytest.fixture(scope="session")
 def site_batch(site_data_config_path) -> TensorBatch:
     dataset = SitesDataset(site_data_config_path)
-    return collate_fn([SiteSample(dataset[i]).to_numpy() for i in range(2)])
+    return collate_fn([SiteSample(dataset[i]) for i in range(2)])
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,7 +278,7 @@ def uk_batch(uk_streamed_datamodule) -> TensorBatch:
 @pytest.fixture(scope="session")
 def site_batch(site_data_config_path) -> TensorBatch:
     dataset = SitesDataset(site_data_config_path)
-    return collate_fn([SiteSample(dataset[i]) for i in range(2)])
+    return collate_fn([dataset[i] for i in range(2)])
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,7 +278,7 @@ def uk_batch(uk_streamed_datamodule) -> TensorBatch:
 @pytest.fixture(scope="session")
 def site_batch(site_data_config_path) -> TensorBatch:
     dataset = SitesDataset(site_data_config_path)
-    return collate_fn([dataset[i] for i in range(2)])
+    return collate_fn([SiteSample(dataset[i]).to_numpy() for i in range(2)])
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Pull Request

## Description

These changes change the amount of historical site data is passed into PVNet, previously with `x["site"][:, : self.history_len + 1]` the t0 time would be included as part of the data sent to the model if for example the `history_minutes` was set to the same amount as the absolute value of the interval start if in the past, e.g.:

With the +1 in the indexing if `interval_start` was -60 and `interval_mintues` is 15 and `history_minutes` is 60 then it would take the first 5 timestamps (60/15 + 1) which would be relative to the t0 time [-60, ...., 0] where the last value is t0, we don't have t0 at inference time so it is better to not include this so the +1 is removed, this is more inline with how the GSP logic in the repo works as well for passing history

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
