### PR TITLE
Move shuffled indices from torch array to numpy array

### DIFF
--- a/pvnet/data/base_datamodule.py
+++ b/pvnet/data/base_datamodule.py
@@ -2,7 +2,7 @@
 
 from glob import glob
 
-import torch
+import numpy as np
 from lightning.pytorch import LightningDataModule
 from ocf_data_sampler.numpy_sample.collate import stack_np_samples_into_batch
 from ocf_data_sampler.numpy_sample.common_types import NumpySample, TensorBatch
@@ -158,10 +158,7 @@ class BaseStreamedDataModule(LightningDataModule):
             # Prepare and pre-shuffle the val dataset and set seed for reproducibility
             val_dataset = self._get_streamed_samples_dataset(*self.val_period)
 
-            if self.seed is not None:
-                torch.manual_seed(self.seed)
-
-            shuffled_indices = torch.randperm(len(val_dataset))
+            shuffled_indices = np.random.default_rng(seed=self.seed).permutation(len(val_dataset))
             self.val_dataset = Subset(val_dataset, shuffled_indices)
 
     def _get_streamed_samples_dataset(


### PR DESCRIPTION
# Pull Request

## Description

Previously we were using a torch tensor to store shuffled index values for the validation dataset. This meant that the index passed was a torch tensor - see openclimatefix/ocf-data-sampler#331

This fixes the issue by moving the shuffled indices array to numpy

The corollary in data-sampler to this PR is openclimatefix/ocf-data-sampler#340

I have tested these two PRs together locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
