### PR TITLE
Add adapt batch check

### DIFF
--- a/pvnet/training/lightning_module.py
+++ b/pvnet/training/lightning_module.py
@@ -105,8 +105,9 @@ class PVNetLightningModule(pl.LightningModule):
         """Run training step"""
         y_hat = self.model(batch)
 
-        # Batch is adapted in the model forward method, but needs to be adapted here too
-        batch = self.model._adapt_batch(batch)
+        # Batch may be adapted in the model forward method, would need adapting here too
+        if self.model.adapt_batches:
+            batch = self.model._adapt_batch(batch)
 
         y = batch[self.model._target_key][:, -self.model.forecast_len :]
 
@@ -211,8 +212,9 @@ class PVNetLightningModule(pl.LightningModule):
             with torch.no_grad():
                 y_hat = self.model(batch)
             
-            # Batch is adapted in the model forward method, but needs to be adapted here too
-            batch = self.model._adapt_batch(batch)
+            # Batch may be adapted in the model forward method, would need adapting here too
+            if self.model.adapt_batches:
+                batch = self.model._adapt_batch(batch)
             
             fig = plot_sample_forecasts(
                 batch,
@@ -233,8 +235,9 @@ class PVNetLightningModule(pl.LightningModule):
         """Run validation step"""
 
         y_hat = self.model(batch)
-        # Batch is adapted in the model forward method, but needs to be adapted here too
-        batch = self.model._adapt_batch(batch)
+        # Batch may be adapted in the model forward method, would need adapting here too
+        if self.model.adapt_batches:
+            batch = self.model._adapt_batch(batch)
 
         # Internally store the val predictions
         self._store_val_predictions(batch, y_hat)


### PR DESCRIPTION
# Pull Request

## Description

Change adds a check to see if `adapt_batches` has been set to `True` first before adapting batches in train/validation loop, prevents unnecessary operations being called when `adapt_batches` hasn't been set and stops some edge cases where forward pass data and backward pass data diverge (can happen with some experiment/hacking around setups). 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
