### PR TITLE
Add hf token parameter

### DIFF
--- a/pvnet/models/base_model.py
+++ b/pvnet/models/base_model.py
@@ -141,7 +141,9 @@ def download_from_hf(
         force_download: Whether to force a new download
         max_retries: Maximum number of retry attempts
         wait_time: Wait time (in seconds) before retrying
-        token: HuggingFace authentication token
+        token: 
+            HF authentication token. If True, the token is read from the HuggingFace config folder.
+            If a string, it is used as the authentication token. 
 
     Returns:
         The local file path of the downloaded file(s)


### PR DESCRIPTION
# Pull Request

## Description

We sometimes download model data from private HF repos which requires some authentication via a token so adding this in as a parameter to prevent errors in our forecasting apps such as [this](https://github.com/openclimatefix/site-forecast-app/actions/runs/17620449931/job/50064613943), defaults to None so should not impact majority of cases where no token is required. 
