### PR TITLE
put warning re: unusable public satellite data in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ satellite:
 
 `ocf-data-sampler` is currently set up to use 11 channels from the satellite data (the 12th, HRV, is not used).
 
+⚠️ NB: Our publicly accessible satellite data is currently saved with a blosc2 compressor, which is not supported by the tensorstore backend PVNet relies on now. We are in the process of updating this; for now, the paths above cannot be used with this codebase.
+
 ### Training PVNet
 
 How PVNet is run is determined by the configuration files. The example configs in `PVNet/configs.example` work with **streamed_samples** using `datamodule/streamed_samples.yaml`.


### PR DESCRIPTION
# Pull Request

The satellite data we have in the public bucket is saved with blosc2 and can't be used in the tensorstore. We've had an OS contributor run into this, so putting a clear warning inn the readme that the paths there cannot actually be used.