### PR TITLE
remove hyprams setting for save val results parameter

### DIFF
--- a/pvnet/training/lightning_module.py
+++ b/pvnet/training/lightning_module.py
@@ -38,6 +38,7 @@ class PVNetLightningModule(pl.LightningModule):
 
         self.model = model
         self._optimizer = optimizer
+        self.save_all_validation_results = save_all_validation_results
 
         # Model must have lr to allow tuning
         # This setting is only used when lr is tuned with callback
@@ -312,7 +313,7 @@ class PVNetLightningModule(pl.LightningModule):
             self.log_dict(extreme_error_metrics, on_step=False, on_epoch=True)
 
             # Optionally save all validation results - these are overridden each epoch
-            if self.hparams.save_all_validation_results:
+            if self.save_all_validation_results:
                 # Add attributes
                 ds_val_results.attrs["epoch"] = self.current_epoch
 


### PR DESCRIPTION
# Pull Request

Set the `save_all_validation_results` parameter to self, so it can be later called and used.

Removed the 'hyprms' part, reverting back to the previous behaviour before the changes made in the commit #461 

## Description

I was getting the following error when running PVNet training:
`AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'") from e
AttributeError: 'AttributeDict' object has no attribute 'save_all_validation_results'
`

## How Has This Been Tested?

Tested locally, and saving as expected locally and to HF.

- [X] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
