### PR TITLE
update target spelling in _store_val_predictions

### DIFF
--- a/pvnet/training/lightning_module.py
+++ b/pvnet/training/lightning_module.py
@@ -151,13 +151,13 @@ class PVNetLightningModule(pl.LightningModule):
     def _store_val_predictions(self, batch: TensorBatch, y_hat: torch.Tensor) -> None:
         """Internally store the validation predictions"""
         
-        taregt_key = self.model._target_key
+        target_key = self.model._target_key
 
-        y = batch[taregt_key][:, -self.model.forecast_len :].cpu().numpy()
+        y = batch[target_key][:, -self.model.forecast_len :].cpu().numpy()
         y_hat = y_hat.cpu().numpy() 
-        ids = batch[f"{taregt_key}_id"].cpu().numpy()
+        ids = batch[f"{target_key}_id"].cpu().numpy()
         init_times_utc = pd.to_datetime(
-            batch[f"{taregt_key}_time_utc"][:, self.model.history_len+1]
+            batch[f"{target_key}_time_utc"][:, self.model.history_len+1]
             .cpu().numpy().astype("datetime64[ns]")
         )
 


### PR DESCRIPTION
# Pull Request

## Description

Small changed to update spelling of the target_key variable in the `_store_val_predictions` function in the lightning module. Changes made just inside the function, with no other instances of the incorrect spelling used elsewhere in the code base.

Fixes #

Fixes the spelling. Additionally I checked for other instances of this and could not find any.

## How Has This Been Tested?

- Passes github CI tests

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
