### PR TITLE
Update comment in trainer config

### DIFF
--- a/configs.example/trainer/default.yaml
+++ b/configs.example/trainer/default.yaml
@@ -1,6 +1,6 @@
 _target_: lightning.Trainer
 
-# set `1` to train on GPU, `0` to train on CPU only
+# set `gpu` to train on GPU, `cpu` to train on CPU only
 accelerator: auto
 devices: auto
 


### PR DESCRIPTION
# Pull Request

[Lightning no longer supports int flags for accelerator](https://lightning.ai/docs/pytorch/stable/common/trainer.html#accelerator), so the comment was out of date.