### PR TITLE
Python version ci hotfix

### DIFF
--- a/pvnet/models/late_fusion/late_fusion.py
+++ b/pvnet/models/late_fusion/late_fusion.py
@@ -150,7 +150,6 @@ class LateFusionModel(BaseModel):
 
         # Number of features expected by the output_network
         # Add to this as network pieces are constructed
-        # testing comment
         fusion_input_features = 0
 
         if self.include_sat:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{name="Peter Dudfield", email="info@openclimatefix.org"}]
 dynamic = ["version"]
 license={file="LICENCE"}
 readme = {file="README.md", content-type="text/markdown"}
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
     "ocf-data-sampler>=0.6.0",


### PR DESCRIPTION
# Pull Request

## Description

Related to https://github.com/openclimatefix/ocf-data-sampler/pull/374

> tensorstore which we rely on due it being used in xarray-tensorstore which is a dependency in this library doesn't seem to fully support python 3.14 yet or at least we run into issues when trying to install it in our CI with python 3.14, e.g. [here](https://github.com/openclimatefix/ocf-data-sampler/actions/runs/19066285088/job/54457640936), as a short term fix to get around this this PR changes the python version supported by ocf-data-sampler to <3.14
