### PR TITLE
Add option to use t0 embedding features

### DIFF
--- a/configs.example/datamodule/configuration/example_configuration.yaml
+++ b/configs.example/datamodule/configuration/example_configuration.yaml
@@ -273,3 +273,9 @@ input_data:
     interval_start_minutes: -60
     interval_end_minutes: 480
     time_resolution_minutes: 30
+
+  # Note that each "cyclic" embedding adds 2 elements to the output vector to embed a period whilst 
+  # "linear" adds only 1 element. This needs to be matched to the model `t0_embedding_dim` param. 
+  # e.g. these embedding would require t0_embedding_dim = 3 (1 + 2).
+  t0_embedding:
+    embeddings: [["1h", "linear"], ["24h", "cyclic"]]

--- a/configs.example/model/late_fusion.yaml
+++ b/configs.example/model/late_fusion.yaml
@@ -69,6 +69,7 @@ model:
   embedding_dim: 16
   include_sun: True
   include_generation_history: False
+  t0_embedding_dim: 3
 
   # The mapping between the location IDs and their embedding indices
   location_id_mapping:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = {file="README.md", content-type="text/markdown"}
 requires-python = ">=3.11,<3.14"
 
 dependencies = [
-    "ocf-data-sampler>=0.6.0",
+    "ocf-data-sampler>=1.0.9",
     "numpy",
     "pandas",
     "matplotlib",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,6 +327,7 @@ def raw_late_fusion_model_kwargs_generation_history(model_minutes_kwargs) -> dic
         embedding_dim=None,
         include_sun=False,
         include_time=True,
+        t0_embedding_dim=3,
         include_generation_history=True,
         forecast_minutes=480, 
         history_minutes=60,

--- a/tests/test_data/data_config.yaml
+++ b/tests/test_data/data_config.yaml
@@ -125,3 +125,6 @@ input_data:
     interval_start_minutes: -60
     interval_end_minutes: 480
     time_resolution_minutes: 30
+
+  t0_embedding:
+    embeddings: [["1h", "linear"], ["24h", "cyclic"]]


### PR DESCRIPTION
# Pull Request

## Description

This adds the option to use the t0-embedding features which were added to data-sampler in openclimatefix/ocf-data-sampler#385 in PVNet

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
