### PR TITLE
Validation functions bug and clean up

### DIFF
--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -6,10 +6,7 @@ import torch
 from pvnet.utils import validate_batch_against_config, validate_gpu_config
 
 
-def test_validate_batch_against_config(
-    batch: dict,
-    late_fusion_model,
-):
+def test_validate_batch_against_config(batch, late_fusion_model):
     """Test batch validation utility function."""
     # This should pass as full uk_batch is valid
     validate_batch_against_config(batch=batch, model=late_fusion_model)
@@ -19,10 +16,7 @@ def test_validate_batch_against_config_raises_error(late_fusion_model):
     """Test that the validation raises an error for a mismatched batch."""
     # Create batch that is missing required NWP data
     minimal_batch = {"generation": torch.randn(2, 17)}
-    with pytest.raises(
-        ValueError,
-        match="Model configured with 'nwp_encoders_dict' but 'nwp' data missing from batch.",
-    ):
+    with pytest.raises(ValueError, match="Model uses NWP data but 'nwp' missing from batch."):
         validate_batch_against_config(batch=minimal_batch, model=late_fusion_model)
 
 
@@ -40,14 +34,7 @@ def test_validate_gpu_config_single_device(trainer_cfg, trainer):
     validate_gpu_config(trainer_cfg(trainer))
 
 
-@pytest.mark.parametrize(
-    "trainer",
-    [
-        {"devices": 2},
-    ],
-    ids=["devices=2"],
-)
-def test_validate_gpu_config_multiple_devices(trainer_cfg, trainer):
+def test_validate_gpu_config_multiple_devices(trainer_cfg):
     """Reject accidental multi-GPU setups."""
     with pytest.raises(ValueError, match="Parallel training not supported"):
-        validate_gpu_config(trainer_cfg(trainer))
+        validate_gpu_config(trainer_cfg({"devices": 2}))


### PR DESCRIPTION
# Pull Request

## Description

There are a few edge case bugs in the validation function that this PR fixes. 

e.g.
 - Some if statement like `if hasattr(model, "nwp_encoders_dict"):`  which always evaluate to true since the model always has `nwp_encoders_dict` even if it is empty. 
 - Looping through the NWP sources in the batch rather than looping through the NWP data that the model requires. The current version doesn't catch missing NWP sources. This new version does.
 
 Plus some other light refactoring and clean ups


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
