### PR TITLE
Fix solar-coord check

### DIFF
--- a/pvnet/utils.py
+++ b/pvnet/utils.py
@@ -147,10 +147,10 @@ def validate_batch_against_config(
             if (sun := batch.get(key)) is None:
                 raise ValueError(f"Model uses solar data but '{key}' missing from batch.")
 
-            _, actual_seq = sun.shape[:2]
+            actual_seq = sun.shape[1]
 
-        if actual_seq != exp_len:
-            raise ValueError(f"Sun {key} mismatch: exp {exp_len}, got {actual_seq}")
+            if actual_seq != exp_len:
+                raise ValueError(f"Sun {key} mismatch: exp {exp_len}, got {actual_seq}")
 
     key = "generation"
     if key in batch:


### PR DESCRIPTION
# Pull Request

## Description

There is a small bug in the solar coord check that it only check the `"solar_elevation"` entry after the loop. Its effectively impossible that the solar_elevation and solar_azimuth are different lengths but it still feels weird not to check them both considering the functionality that's already there.

Alse replaced a strange tuple unpacking we were doing in the function