### PR TITLE
Make val and train periods more flexible

### DIFF
--- a/configs.example/datamodule/streamed_samples.yaml
+++ b/configs.example/datamodule/streamed_samples.yaml
@@ -8,12 +8,12 @@ prefetch_factor: 2
 persistent_workers: false
 batch_size: 8
 
-train_period:
-  - null
-  - "2022-05-07"
-val_period:
-  - "2022-05-08"
-  - "2023-05-08"
+train_periods:
+  - [null, '2021-12-31']
+  - ['2023-01-01', '2025-12-31']
+    
+val_periods:
+  - ['2022-01-01', '2022-12-31']
 
 seed: "${seed}"
 

--- a/pvnet/datamodule.py
+++ b/pvnet/datamodule.py
@@ -22,13 +22,13 @@ class PVNetDataModule(LightningDataModule):
     def __init__(
         self,
         configuration: str,
-        batch_size: int = 16,
+        train_periods: list[tuple[None | str, None | str]],
+        val_periods: list[tuple[None | str, None | str]],
+        batch_size: int,
         num_workers: int = 0,
         prefetch_factor: int | None = None,
         persistent_workers: bool = False,
         pin_memory: bool = False,
-        train_period: list[str | None] = [None, None],
-        val_period: list[str | None] = [None, None],
         seed: int | None = None,
         dataset_pickle_dir: str | None = None,
     ):
@@ -36,6 +36,10 @@ class PVNetDataModule(LightningDataModule):
 
         Args:
             configuration: Path to ocf-data-sampler configuration file.
+            train_periods: List of (start_time, end_time) tuples for the train dataset. If 
+                start_time or end_time is None, it means that there is no lower/upper bound on the 
+                time period.
+            val_periods: List of (start_time, end_time) tuples for the validation dataset.
             batch_size: Batch size.
             num_workers: Number of workers to use in multiprocess batch loading.
             prefetch_factor: Number of batches loaded in advance by each worker.
@@ -44,8 +48,6 @@ class PVNetDataModule(LightningDataModule):
                 instances alive.
             pin_memory: If True, the data loader will copy Tensors into device/CUDA pinned memory
                 before returning them.
-            train_period: Date range filter for train dataloader.
-            val_period: Date range filter for val dataloader.
             seed: Random seed used in shuffling datasets.
             dataset_pickle_dir: Directory in which the val and train set will be presaved as
                 pickle objects. Setting this speeds up instantiation of multiple workers a lot.
@@ -53,8 +55,8 @@ class PVNetDataModule(LightningDataModule):
         super().__init__()
 
         self.configuration = configuration
-        self.train_period = train_period
-        self.val_period = val_period
+        self.train_periods = train_periods
+        self.val_periods = val_periods
         self.seed = seed
         self.dataset_pickle_dir = dataset_pickle_dir
 
@@ -79,10 +81,10 @@ class PVNetDataModule(LightningDataModule):
         # shuffled once
         if stage == "fit":
             # Prepare the train dataset
-            self.train_dataset = self._get_dataset(*self.train_period)
+            self.train_dataset = self._get_dataset(self.train_periods)
 
             # Prepare and pre-shuffle the val dataset and set seed for reproducibility
-            val_dataset = self._get_dataset(*self.val_period)
+            val_dataset = self._get_dataset(self.val_periods)
 
             shuffled_indices = np.random.default_rng(seed=self.seed).permutation(len(val_dataset))
             self.val_dataset = Subset(val_dataset, shuffled_indices)
@@ -114,8 +116,8 @@ class PVNetDataModule(LightningDataModule):
                 if os.path.exists(filepath):
                     os.remove(filepath)
 
-    def _get_dataset(self, start_time: str | None, end_time: str | None) -> PVNetDataset:
-        return PVNetDataset(self.configuration, start_time=start_time, end_time=end_time)
+    def _get_dataset(self, time_periods: list[tuple[str | None, str | None]]) -> PVNetDataset:
+        return PVNetDataset(self.configuration, time_periods=time_periods)
 
     def train_dataloader(self) -> DataLoader:
         """Construct train dataloader"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = {file="README.md", content-type="text/markdown"}
 requires-python = ">=3.11,<3.14"
 
 dependencies = [
-    "ocf-data-sampler>=1.0.9",
+    "ocf-data-sampler>=1.0.19",
     "numpy",
     "pandas",
     "matplotlib",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,8 @@ def data_config_path(
 @pytest.fixture(scope="session")
 def streamed_datamodule(data_config_path) -> PVNetDataModule:
     dm = PVNetDataModule(
+        train_periods=[[None, None]],
+        val_periods=[[None, None]],
         configuration=data_config_path,
         batch_size=2,
         num_workers=0,

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -10,6 +10,6 @@ def test_data_module(data_config_path):
         batch_size=2,
         num_workers=0,
         prefetch_factor=None,
-        train_period=[None, None],
-        val_period=[None, None],
+        train_periods=[[None, None]],
+        val_periods=[[None, None]],
     )

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -10,6 +10,8 @@ def test_model_trainer_fit(session_tmp_path, data_config_path, late_fusion_model
 
     datamodule = PVNetDataModule(
         configuration=data_config_path,
+        train_periods=[[None, None]],
+        val_periods=[[None, None]],
         batch_size=2,
         num_workers=2,
         prefetch_factor=None,

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -110,6 +110,8 @@ def test_train_pvnet(
         "seed": 42,
         "datamodule": {
             "_target_": "pvnet.datamodule.PVNetDataModule",
+            "train_periods": [[None, None]],
+            "val_periods": [[None, None]],
             "configuration": str(data_config_path),
             "batch_size": 2,
             "num_workers": 0,
@@ -122,6 +124,7 @@ def test_train_pvnet(
         "logger": logger_cfg,
         "callbacks": ckpt_cfg,
         "trainer": trainer_cfg_cpu,
+        "model_name": "test_model",
     })
 
     pvnet_train(cfg)


### PR DESCRIPTION
# Pull Request

## Description

Adds support for openclimatefix/ocf-data-sampler#412

This allows the training and validation datasets to be composed of different periods instead of our current restricted approach where the val period is always after the train period

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
