### PR TITLE
Explicit error if devices: auto & >1 GPU available and if devices >1

### DIFF
--- a/pvnet/utils.py
+++ b/pvnet/utils.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING
 
 import rich.syntax
 import rich.tree
+import torch
 from lightning.pytorch.utilities import rank_zero_only
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 if TYPE_CHECKING:
     from pvnet.models.base_model import BaseModel
@@ -167,13 +168,48 @@ def validate_batch_against_config(
 
 
 def validate_gpu_config(config: DictConfig) -> None:
-    """Abort if multiple GPUs requested by mistake i.e. `devices: 2` instead of `[2]`."""
-    tr = config.get("trainer", {})
-    dev = tr.get("devices")
+    """
+    Abort if the config may use multiple GPUs.
 
-    if isinstance(dev, int) and dev > 1:
-        raise ValueError(
-            f"Detected `devices: {dev}` — this requests {dev} GPUs. "
-            "If you meant a specific GPU (e.g. GPU 2), use `devices: [2]`. "
-            "Parallel training not supported."
+    PVNet does not currently support parallel training. This validation only
+    raises when multiple CUDA GPUs are actually available and the trainer config
+    could select more than one of them.
+    """
+    trainer_config = config.get("trainer", {})
+    devices = trainer_config.get("devices")
+    accelerator = str(trainer_config.get("accelerator", "auto")).lower()
+
+    num_available_gpus = torch.cuda.device_count()
+
+    if num_available_gpus <= 1:
+        return
+
+    if accelerator in {"cpu", "mps", "tpu"}:
+        return
+
+    if devices == "auto":
+        msg = (
+            f"`devices: 'auto'` may use all {num_available_gpus} available GPUs. "
+            "PVNet does not support multi-GPU training. "
+            "Use a single explicit device, for example `devices: [0]`."
         )
+    elif (
+        isinstance(devices, int)
+        and not isinstance(devices, bool)
+        and devices > 1
+    ):
+        msg = (
+            f"Detected `devices: {devices}` with {num_available_gpus} GPUs available. "
+            "This requests multiple GPUs. PVNet does not support multi-GPU training. "
+            "If you meant to select a specific GPU, for example GPU 2, use `devices: [2]`."
+        )
+    elif isinstance(devices, (list, tuple, ListConfig)) and len(devices) > 1:
+        msg = (
+            f"Detected `devices: {list(devices)}` with {num_available_gpus} GPUs available. "
+            "This requests multiple GPUs. PVNet does not support multi-GPU training. "
+            "Use a single explicit device, for example `devices: [0]`."
+        )
+    else:
+        return
+
+    raise ValueError(msg)

--- a/pvnet/utils.py
+++ b/pvnet/utils.py
@@ -168,8 +168,7 @@ def validate_batch_against_config(
 
 
 def validate_gpu_config(config: DictConfig) -> None:
-    """
-    Abort if the config may use multiple GPUs.
+    """Abort if the config may use multiple GPUs.
 
     PVNet does not currently support parallel training. This validation only
     raises when multiple CUDA GPUs are actually available and the trainer config
@@ -193,11 +192,7 @@ def validate_gpu_config(config: DictConfig) -> None:
             "PVNet does not support multi-GPU training. "
             "Use a single explicit device, for example `devices: [0]`."
         )
-    elif (
-        isinstance(devices, int)
-        and not isinstance(devices, bool)
-        and devices > 1
-    ):
+    elif isinstance(devices, int) and devices > 1:
         msg = (
             f"Detected `devices: {devices}` with {num_available_gpus} GPUs available. "
             "This requests multiple GPUs. PVNet does not support multi-GPU training. "

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -23,21 +23,64 @@ def test_validate_batch_against_config_raises_error(late_fusion_model):
 @pytest.mark.parametrize(
     "trainer",
     [
-        {"devices": 1},
-        {"devices": [0]},
+        {"devices": "auto"},
+        {"devices": 2},
+        {"devices": [0, 1]},
+    ],
+    ids=["devices=auto", "devices=2", "devices=[0,1]"],
+)
+
+def test_validate_gpu_config_rejects_multi_gpu_configs_when_multiple_gpus_available(
+    trainer_cfg,
+    trainer,
+    monkeypatch,
+):
+    """Reject configs that may use multiple GPUs when multiple GPUs are available."""
+    monkeypatch.setattr("pvnet.utils.torch.cuda.device_count", lambda: 2)
+
+    with pytest.raises(ValueError, match="does not support multi-GPU training"):
+        validate_gpu_config(trainer_cfg(trainer))
+
+@pytest.mark.parametrize(
+    "trainer",
+    [
+        {"devices": "auto"},
+        {"devices": 2},
+        {"devices": [0, 1]},
         {"accelerator": "cpu"},
     ],
-    ids=["devices=1", "devices=[0]", "accelerator=cpu"],
+    ids=["devices=auto", "devices=2", "devices=[0,1]", "accelerator=cpu"],
 )
-def test_validate_gpu_config_single_device(trainer_cfg, trainer):
-    """Accept single GPU or explicit CPU configurations."""
+
+def test_validate_gpu_config_allows_configs_when_only_one_gpu_available(
+    trainer_cfg,
+    trainer,
+    monkeypatch,
+):
+    """Do not raise if multi-GPU training is impossible on the current machine."""
+    monkeypatch.setattr("pvnet.utils.torch.cuda.device_count", lambda: 1)
+
     validate_gpu_config(trainer_cfg(trainer))
 
+@pytest.mark.parametrize(
+    "trainer",
+    [
+        {"devices": 1},
+        {"devices": [0]},
+        {"accelerator": "cpu", "devices": "auto"},
+    ],
+    ids=["devices=1", "devices=[0]", "cpu-auto"],
+)
 
-def test_validate_gpu_config_multiple_devices(trainer_cfg):
-    """Reject accidental multi-GPU setups."""
-    with pytest.raises(ValueError, match="Parallel training not supported"):
-        validate_gpu_config(trainer_cfg({"devices": 2}))
+def test_validate_gpu_config_allows_single_device_configs(
+    trainer_cfg,
+    trainer,
+    monkeypatch,
+):
+    """Allow configs that cannot use multiple CUDA GPUs."""
+    monkeypatch.setattr("pvnet.utils.torch.cuda.device_count", lambda: 2)
+
+    validate_gpu_config(trainer_cfg(trainer))
 
 
 def test_validate_batch_longer_sequence(batch, late_fusion_model):

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -47,9 +47,8 @@ def test_validate_gpu_config_rejects_multi_gpu_configs_when_multiple_gpus_availa
         {"devices": "auto"},
         {"devices": 2},
         {"devices": [0, 1]},
-        {"accelerator": "cpu"},
     ],
-    ids=["devices=auto", "devices=2", "devices=[0,1]", "accelerator=cpu"],
+    ids=["devices=auto", "devices=2", "devices=[0,1]"],
 )
 
 def test_validate_gpu_config_allows_configs_when_only_one_gpu_available(


### PR DESCRIPTION
# Pull Request

## Description

Summary of changes:

- Check available CUDA GPU count before rejecting trainer configs.
- Reject `devices: "auto"` only when multiple GPUs are available.
- Reject explicit multi-GPU configs such as `devices: 2` and `devices: [0, 1]` when multiple GPUs are available.
- Allow safe configs such as `devices: 1`, `devices: [0]`, and `accelerator: cpu`.
- No extra dependencies required

Change motivated by non explicit error previously being raised and discussion during ML chat

## Fixes 

Testing:

- `uv run python -m pytest tests/models/test_validation.py`
- test validate gpu config rejects multi gpu configs when mutliple gpus available
- test validate gpu config allows configs when only one gpu available
- test validate gpu config allows single device configs

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
