### PR TITLE
Updates

### DIFF
--- a/pvnet/training/lightning_module.py
+++ b/pvnet/training/lightning_module.py
@@ -153,6 +153,8 @@ class PVNetLightningModule(pl.LightningModule):
         """Internally store the validation predictions"""
 
         y = batch["generation"][:, -self.model.forecast_len :].cpu().numpy()
+        # .float() as numpy has no bfloat16 dtype
+        # Fails under precision="bf16-mixed"
         y_hat = y_hat.float().cpu().numpy()
         ids = batch["location_id"].cpu().numpy()
         init_times_utc = pd.to_datetime(

--- a/pvnet/training/lightning_module.py
+++ b/pvnet/training/lightning_module.py
@@ -153,7 +153,7 @@ class PVNetLightningModule(pl.LightningModule):
         """Internally store the validation predictions"""
 
         y = batch["generation"][:, -self.model.forecast_len :].cpu().numpy()
-        y_hat = y_hat.cpu().numpy()
+        y_hat = y_hat.float().cpu().numpy()
         ids = batch["location_id"].cpu().numpy()
         init_times_utc = pd.to_datetime(
             batch["time_utc"][:, self.model.history_len + 1].cpu().numpy().astype("datetime64[ns]")

--- a/run.py
+++ b/run.py
@@ -16,6 +16,8 @@ from pvnet.utils import print_config, run_config_utilities, validate_gpu_config
 
 logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
 
+# Use TF32 tensor cores for fp32 matmuls / convs
+# Solid speedup with negligible precision loss
 torch.set_float32_matmul_precision("high")
 
 

--- a/run.py
+++ b/run.py
@@ -8,6 +8,7 @@ import logging
 import sys
 
 import hydra
+import torch
 from omegaconf import DictConfig
 
 from pvnet.training import train
@@ -15,6 +16,7 @@ from pvnet.utils import print_config, run_config_utilities, validate_gpu_config
 
 logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
 
+torch.set_float32_matmul_precision("high")
 
 
 @hydra.main(config_path="configs/", config_name="config.yaml", version_base="1.2")


### PR DESCRIPTION
Enable TF32 tensor cores and make validation bf16-safe

- `run.py`: add `torch.set_float32_matmul_precision("high")` — lets fp32 matmuls / convs use tensor cores on Ampere+ GPUs. Free speedup, negligible precision cost.
- `lightning_module.py`: `y_hat.float().cpu().numpy()` in val storage - fixes a crash when training with `precision=bf16-mixed` (numpy has no bfloat16). No-op under fp32.

Tested on A6000 (DE model): GPU fully utilised, no change to training behaviour.