### PR TITLE
save_last to save last checkpoint

### DIFF
--- a/configs.example/callbacks/default.yaml
+++ b/configs.example/callbacks/default.yaml
@@ -20,7 +20,7 @@ model_checkpoint:
   monitor: "${resolve_monitor_loss:${model.model.output_quantiles}}"
   mode: "min" # can be "max" or "min"
   save_top_k: 1 # save k best models (determined by above metric)
-  save_last: True # save a last.ckpt copy whenever a checkpoint file gets saved
+  save_last: False # save a last.ckpt copy whenever a checkpoint file gets saved
   every_n_epochs: 1
   verbose: False
   filename: "epoch={epoch}-step={step}"
@@ -28,3 +28,13 @@ model_checkpoint:
   dirpath: "PLACEHOLDER/${model_name}" #${..model_name}
   auto_insert_metric_name: False
   save_on_train_epoch_end: False
+
+last_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  monitor: null
+  save_top_k: 1
+  filename: "last"
+  every_n_epochs: 1
+  enable_version_counter: False
+  save_on_train_epoch_end: False
+  dirpath: "PLACEHOLDER/${model_name}"

--- a/configs.example/callbacks/default.yaml
+++ b/configs.example/callbacks/default.yaml
@@ -17,8 +17,11 @@ model_summary:
 model_checkpoint:
   _target_: lightning.pytorch.callbacks.ModelCheckpoint
   # name of the logged metric which determines when model is improving
+  monitor: "${resolve_monitor_loss:${model.model.output_quantiles}}"
   mode: "min" # can be "max" or "min"
-  save_last: False # last.ckpt saved by different callback below
+  save_top_k: 1 # save k best models (determined by above metric)
+  save_last: False # last.ckpt is saved by the last_checkpoint callback below
+  every_n_epochs: 1
   verbose: False
   filename: "epoch={epoch}-step={step}"
   # The path to where the model checkpoints will be stored
@@ -26,13 +29,10 @@ model_checkpoint:
   auto_insert_metric_name: False
   save_on_train_epoch_end: False
 
-# Saves model from most recent epoch to last.ckpt, overwriting each instance
+# Saves the model from the most recent epoch to last.ckpt, overwriting it each time
 last_checkpoint:
   _target_: lightning.pytorch.callbacks.ModelCheckpoint
-  monitor: null
-  save_top_k: 1
   filename: "last"
-  every_n_epochs: 1
   enable_version_counter: False
   save_on_train_epoch_end: False
   dirpath: "PLACEHOLDER/${model_name}"

--- a/configs.example/callbacks/default.yaml
+++ b/configs.example/callbacks/default.yaml
@@ -17,11 +17,8 @@ model_summary:
 model_checkpoint:
   _target_: lightning.pytorch.callbacks.ModelCheckpoint
   # name of the logged metric which determines when model is improving
-  monitor: "${resolve_monitor_loss:${model.model.output_quantiles}}"
   mode: "min" # can be "max" or "min"
-  save_top_k: 1 # save k best models (determined by above metric)
-  save_last: False # save a last.ckpt copy whenever a checkpoint file gets saved
-  every_n_epochs: 1
+  save_last: False # last.ckpt saved by different callback below
   verbose: False
   filename: "epoch={epoch}-step={step}"
   # The path to where the model checkpoints will be stored
@@ -29,6 +26,7 @@ model_checkpoint:
   auto_insert_metric_name: False
   save_on_train_epoch_end: False
 
+# Saves model from most recent epoch to last.ckpt, overwriting each instance
 last_checkpoint:
   _target_: lightning.pytorch.callbacks.ModelCheckpoint
   monitor: null

--- a/configs.example/callbacks/default.yaml
+++ b/configs.example/callbacks/default.yaml
@@ -20,7 +20,6 @@ model_checkpoint:
   monitor: "${resolve_monitor_loss:${model.model.output_quantiles}}"
   mode: "min" # can be "max" or "min"
   save_top_k: 1 # save k best models (determined by above metric)
-  save_last: False # last.ckpt is saved by the last_checkpoint callback below
   every_n_epochs: 1
   verbose: False
   filename: "epoch={epoch}-step={step}"

--- a/pvnet/training/train.py
+++ b/pvnet/training/train.py
@@ -85,31 +85,29 @@ def train(config: DictConfig) -> None:
 
     # Set the output directory based in the wandb-id of the run
     if use_wandb_logger:
-        for callback in callbacks:
-            if isinstance(callback, ModelCheckpoint):
-                # Calling the .experiment property instantiates a wandb run
-                wandb_id = wandb_logger.experiment.id
+        ckpt_callbacks = [cb for cb in callbacks if isinstance(cb, ModelCheckpoint)]
+        if ckpt_callbacks:
+            wandb_id = wandb_logger.experiment.id
 
-                # Save the run results to the expected parent folder but with the folder name
-                # set by the wandb ID
-                save_dir = "/".join(callback.dirpath.split("/")[:-1] + [wandb_id])
+            # Save run results to the expected folder but with folder name set by ID
+            save_dir = "/".join(ckpt_callbacks[0].dirpath.split("/")[:-1] + [wandb_id])
 
-                callback.dirpath = save_dir
-                
-                # Save the model config
-                os.makedirs(save_dir, exist_ok=True)
-                OmegaConf.save(config.model, f"{save_dir}/{MODEL_CONFIG_NAME}")
+            # Point every ckpt callback (best + last) at same folder
+            for cb in ckpt_callbacks:
+                cb.dirpath = save_dir
 
-                # Save the data config to the output directory and to wandb
-                data_config = config.datamodule.configuration
-                shutil.copyfile(data_config, f"{save_dir}/{DATA_CONFIG_NAME}")
-                wandb_logger.experiment.save(f"{save_dir}/{DATA_CONFIG_NAME}", base_path=save_dir)
+            # Save model config
+            os.makedirs(save_dir, exist_ok=True)
+            OmegaConf.save(config.model, f"{save_dir}/{MODEL_CONFIG_NAME}")
 
-                # Save the full hydra config to the output directory and to wandb
-                OmegaConf.save(config, f"{save_dir}/{FULL_CONFIG_NAME}")
-                wandb_logger.experiment.save(f"{save_dir}/{FULL_CONFIG_NAME}", base_path=save_dir)
-                
-                break
+            # Save data config to output directory and to wandb
+            data_config = config.datamodule.configuration
+            shutil.copyfile(data_config, f"{save_dir}/{DATA_CONFIG_NAME}")
+            wandb_logger.experiment.save(f"{save_dir}/{DATA_CONFIG_NAME}", base_path=save_dir)
+
+            # Save full hydra config to output directory and to wandb
+            OmegaConf.save(config, f"{save_dir}/{FULL_CONFIG_NAME}")
+            wandb_logger.experiment.save(f"{save_dir}/{FULL_CONFIG_NAME}", base_path=save_dir)
 
     trainer: Trainer = hydra.utils.instantiate(
         config.trainer,

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -50,15 +50,23 @@ def logger_cfg(wandb_save_dir: str) -> dict:
 @pytest.fixture()
 def ckpt_cfg(wandb_save_dir: str) -> dict:
     """ModelCheckpoint config."""
+    ckpt_dir = str(Path(wandb_save_dir).parent / "ckpts")
     return {
         "ckpt": {
             "_target_": "lightning.pytorch.callbacks.ModelCheckpoint",
-            "dirpath": str(Path(wandb_save_dir).parent / "ckpts"),
-            "save_last": True,
+            "dirpath": ckpt_dir,
             "save_top_k": 1,
             "monitor": "MAE/val",
             "mode": "min",
-        }
+            "save_on_train_epoch_end": False,
+        },
+        "last_ckpt": {
+            "_target_": "lightning.pytorch.callbacks.ModelCheckpoint",
+            "dirpath": ckpt_dir,
+            "filename": "last",
+            "enable_version_counter": False,
+            "save_on_train_epoch_end": False,
+        },
     }
 
 


### PR DESCRIPTION
Related to https://github.com/openclimatefix/pvnet/issues/542

- `save_last: True` was meant to save the model from the most recent epoch to `last.ckpt`.
- L 2.6.0 `last.ckpt` is written when a top-k checkpoint is saved at the same step.
- Used `save_top_k: 1`, so only happens when validation loss improves, and `last.ckpt` ends up being a copy of the best ckpt.
- Before 2.6, `save_last: True` did save real last epoch.

Changes:
- `configs.example/callbacks/default.yaml`: turned off `save_last`. added second `ModelCheckpoint` with `last_checkpoint`. Hence saves after every validation and overwrites `last.ckpt` each time.
- `pvnet/training/train.py`: Both callbacks now to be saved to the same run folder. The config files are still saved once, as before.
- `tests/training/test_train.py`: Updated fixture accordingly